### PR TITLE
refactor: Achievement Badges

### DIFF
--- a/model/enum/wikibase_log_type_enum.py
+++ b/model/enum/wikibase_log_type_enum.py
@@ -101,6 +101,11 @@ def compile_log_type(record: dict) -> WikibaseLogType:
     """Compile Log Type"""
 
     log_type: Optional[WikibaseLogType] = None
+    
+    match record['type']:
+        case 'achievementbadges':
+            log_type = WikibaseLogType.ACHIEVEMENT_BADGE
+
     match (record["type"], record["action"]):
         case ("create", "create"):
             if ITEM_REGEX.match(record["title"]) is not None:
@@ -120,23 +125,6 @@ def compile_log_type(record: dict) -> WikibaseLogType:
             log_type = WikibaseLogType.ABUSE_FILTER_CREATE
         case ("abusefilter", "modify"):
             log_type = WikibaseLogType.ABUSE_FILTER_MODIFIY
-        case (
-            ("achievementbadges", "be-thanked")
-            | ("achievementbadges", "contribs-sunday")
-            | ("achievementbadges", "contribs-monday")
-            | ("achievementbadges", "contribs-tuesday")
-            | ("achievementbadges", "contribs-thursday")
-            | ("achievementbadges", "contribs-friday")
-            | ("achievementbadges", "contribs-saturday")
-            | ("achievementbadges", "create-page")
-            | ("achievementbadges", "edit-page")
-            | ("achievementbadges", "edit-size")
-            | ("achievementbadges", "long-user-page")
-            | ("achievementbadges", "sign-up")
-            | ("achievementbadges", "thanks")
-            | ("achievementbadges", "visual-edit")
-        ):
-            log_type = WikibaseLogType.ACHIEVEMENT_BADGE
         case ("approval", "approve"):
             log_type = WikibaseLogType.APPROVE
         case ("comments", "add"):

--- a/model/enum/wikibase_log_type_enum.py
+++ b/model/enum/wikibase_log_type_enum.py
@@ -101,9 +101,9 @@ def compile_log_type(record: dict) -> WikibaseLogType:
     """Compile Log Type"""
 
     log_type: Optional[WikibaseLogType] = None
-    
-    match record['type']:
-        case 'achievementbadges':
+
+    match record["type"]:
+        case "achievementbadges":
             log_type = WikibaseLogType.ACHIEVEMENT_BADGE
 
     match (record["type"], record["action"]):


### PR DESCRIPTION
Certain logs are merged into one group by just the action, but may have many distinct types. In specific, the ACHIEVEMENT_BADGE logs are now grouped together, and we do not have to deal with an error every time there's a new one.