### PR TITLE
Update Requirements

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v3
+        with:
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -23,6 +25,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v3
+        with:
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -36,6 +40,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v3
+        with:
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -49,6 +55,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v3
+        with:
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/alembic/versions/e2f94a8e2beb_init.py
+++ b/alembic/versions/e2f94a8e2beb_init.py
@@ -1,7 +1,7 @@
 """init
 
 Revision ID: e2f94a8e2beb
-Revises: 
+Revises:
 Create Date: 2024-06-07 13:25:42.337502
 
 """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black>=24.10.0
+black>=25.1.0
 freezegun>=1.5.1
 great-expectations>=1.3.3
 pylint>=3.3.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 black>=24.10.0
 freezegun>=1.5.1
-great-expectations>=1.3.1
+great-expectations>=1.3.3
 pylint>=3.3.3
 pytest>=8.3.4
 pytest-asyncio>=0.25.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 aiosqlite>=0.20.0
-alembic>=1.14.0
+alembic>=1.14.1
 APScheduler>=3.11.0
 beautifulsoup4>=4.12.3
-fastapi[standard]>=0.115.6
+fastapi[standard]>=0.115.7
 gunicorn>=23.0.0
 httpx>=0.28.1
 numpy>=1.26.4,<2.0
 requests>=2.32.3
 SPARQLWrapper>=2.0.0
 sqlalchemy[asyncio]>=2.0.37
-strawberry-graphql[fastapi]>=0.257.0
+strawberry-graphql[fastapi]>=0.258.0
 tqdm>=4.67.1
 uvicorn[standard]>=0.34.0


### PR DESCRIPTION
Github Actions now uses Python 3.13; this isn't compatible with GX
New major version of `black` out