### PR TITLE
refactor!: Type Names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__
 .~lock*
 virtualenv/
+venv*/
 .ipynb_checkpoints/
 fetch_data/sparql_data/sparql_queries/failed_queries/
 .coverage

--- a/model/strawberry/output/observation/connectivity/relationship_count.py
+++ b/model/strawberry/output/observation/connectivity/relationship_count.py
@@ -9,7 +9,7 @@ from model.database import (
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseConnectivityObservationRelationshipCount")
 class WikibaseConnectivityObservationRelationshipCountStrawberryModel:
     """Wikibase Connectivity Observation Relationship Counts"""
 
@@ -19,7 +19,7 @@ class WikibaseConnectivityObservationRelationshipCountStrawberryModel:
     )
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseConnectivityObservationItemRelationshipCount")
 class WikibaseConnectivityObservationItemRelationshipCountStrawberryModel(
     WikibaseConnectivityObservationRelationshipCountStrawberryModel
 ):
@@ -42,7 +42,7 @@ class WikibaseConnectivityObservationItemRelationshipCountStrawberryModel(
         )
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseConnectivityObservationObjectRelationshipCount")
 class WikibaseConnectivityObservationObjectRelationshipCountStrawberryModel(
     WikibaseConnectivityObservationRelationshipCountStrawberryModel
 ):

--- a/model/strawberry/output/observation/connectivity/wikibase_connectivity_observation.py
+++ b/model/strawberry/output/observation/connectivity/wikibase_connectivity_observation.py
@@ -14,7 +14,7 @@ from model.strawberry.output.observation.wikibase_observation import (
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseConnectivityObservation")
 class WikibaseConnectivityObservationStrawberryModel(
     WikibaseObservationStrawberryModel
 ):

--- a/model/strawberry/output/observation/log/wikibase_created_aggregate.py
+++ b/model/strawberry/output/observation/log/wikibase_created_aggregate.py
@@ -5,7 +5,7 @@ import strawberry
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseYearCreatedAggregate")
 class WikibaseYearCreatedAggregateStrawberryModel:
     """Aggregate Year Created"""
 

--- a/model/strawberry/output/observation/log/wikibase_log.py
+++ b/model/strawberry/output/observation/log/wikibase_log.py
@@ -5,14 +5,14 @@ from typing import Optional
 import strawberry
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseLog")
 class WikibaseLogStrawberryModel:
     """Wikibase Log"""
 
     date: datetime = strawberry.field(description="Log Date")
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseLogUser")
 class WikibaseLogUserStrawberryModel(WikibaseLogStrawberryModel):
     """Wikibase Log"""
 

--- a/model/strawberry/output/observation/log/wikibase_log_collection.py
+++ b/model/strawberry/output/observation/log/wikibase_log_collection.py
@@ -12,7 +12,7 @@ from model.enum import WikibaseLogType, WikibaseUserType
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseLogCollection")
 class WikibaseLogCollectionStrawberryModel:
     """Wikibase Log Collection"""
 
@@ -28,7 +28,7 @@ class WikibaseLogCollectionStrawberryModel:
     last_log_date: datetime = strawberry.field(description="Last Log Date")
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseLogMonthLogType")
 class WikibaseLogMonthLogTypeStrawberryModel(WikibaseLogCollectionStrawberryModel):
     """Wikibase Log Month, specific Log Type"""
 
@@ -54,7 +54,7 @@ class WikibaseLogMonthLogTypeStrawberryModel(WikibaseLogCollectionStrawberryMode
         )
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseLogMonthUserType")
 class WikibaseLogMonthUserTypeStrawberryModel(WikibaseLogCollectionStrawberryModel):
     """Wikibase Log Month, specific User Type"""
 

--- a/model/strawberry/output/observation/log/wikibase_log_month_observation.py
+++ b/model/strawberry/output/observation/log/wikibase_log_month_observation.py
@@ -18,7 +18,7 @@ from model.strawberry.output.observation.wikibase_observation import (
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseLogMonth")
 class WikibaseLogMonthStrawberryModel(WikibaseObservationStrawberryModel):
     """Wikibase Log Month"""
 

--- a/model/strawberry/output/observation/log/wikibase_log_observation.py
+++ b/model/strawberry/output/observation/log/wikibase_log_observation.py
@@ -11,7 +11,7 @@ from model.strawberry.output.observation.wikibase_observation_set import (
 )
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseLogObservation")
 class WikibaseLogObservationStrawberryModel:
     """Wikibase Log Data Observation"""
 

--- a/model/strawberry/output/observation/property_popularity/aggregate_count.py
+++ b/model/strawberry/output/observation/property_popularity/aggregate_count.py
@@ -8,7 +8,7 @@ from model.strawberry.output.observation.property_popularity.count import (
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibasePropertyPopularityAggregateCount")
 class WikibasePropertyPopularityAggregateCountStrawberryModel(
     WikibasePropertyPopularityCountStrawberryModel
 ):

--- a/model/strawberry/output/observation/property_popularity/count.py
+++ b/model/strawberry/output/observation/property_popularity/count.py
@@ -6,7 +6,7 @@ from model.database import WikibasePropertyPopularityCountModel
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibasePropertyPopularityCount")
 class WikibasePropertyPopularityCountStrawberryModel:
     """Wikibase Property Popularity Count"""
 

--- a/model/strawberry/output/observation/property_popularity/observation.py
+++ b/model/strawberry/output/observation/property_popularity/observation.py
@@ -11,7 +11,7 @@ from model.strawberry.output.observation.wikibase_observation import (
 )
 
 
-@strawberry.type
+@strawberry.type(name="WikibasePropertyPopularityObservation")
 class WikibasePropertyPopularityObservationStrawberryModel(
     WikibaseObservationStrawberryModel
 ):

--- a/model/strawberry/output/observation/quantity/wikibase_quantity_aggregate.py
+++ b/model/strawberry/output/observation/quantity/wikibase_quantity_aggregate.py
@@ -5,7 +5,7 @@ import strawberry
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseQuantityAggregate")
 class WikibaseQuantityAggregateStrawberryModel:
     """Aggregate Quantity"""
 

--- a/model/strawberry/output/observation/quantity/wikibase_quantity_observation.py
+++ b/model/strawberry/output/observation/quantity/wikibase_quantity_observation.py
@@ -10,7 +10,7 @@ from model.strawberry.output.observation.wikibase_observation import (
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseQuantityObservation")
 class WikibaseQuantityObservationStrawberryModel(WikibaseObservationStrawberryModel):
     """Wikibase Quantity Data Observation"""
 

--- a/model/strawberry/output/observation/software_version/software_version.py
+++ b/model/strawberry/output/observation/software_version/software_version.py
@@ -8,7 +8,7 @@ from model.database import WikibaseSoftwareVersionModel
 from model.strawberry.output.wikibase_software import WikibaseSoftwareStrawberryModel
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseSoftwareVersion")
 class WikibaseSoftwareVersionStrawberryModel:
     """Wikibase Software Version"""
 

--- a/model/strawberry/output/observation/software_version/software_version_aggregate.py
+++ b/model/strawberry/output/observation/software_version/software_version_aggregate.py
@@ -9,7 +9,7 @@ from model.strawberry.output.semver import Semver
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseSoftwareVersionAggregate")
 class WikibaseSoftwareVersionAggregateStrawberryModel:
     """Wikibase Software Version Aggregate"""
 
@@ -48,7 +48,7 @@ class WikibaseSoftwareVersionAggregateStrawberryModel:
                 )
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseSoftwareMidVersionAggregate")
 class WikibaseSoftwareMidVersionAggregateStrawberryModel:
     """Aggregated to X Version - ABSTRACT"""
 
@@ -65,7 +65,7 @@ class WikibaseSoftwareMidVersionAggregateStrawberryModel:
         return sum(v.wikibase_count for v in self.private_versions)
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseSoftwarePatchVersionAggregate")
 class WikibaseSoftwarePatchVersionAggregateStrawberryModel(
     WikibaseSoftwareMidVersionAggregateStrawberryModel
 ):
@@ -92,7 +92,7 @@ class WikibaseSoftwarePatchVersionAggregateStrawberryModel(
         )
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseSoftwareMinorVersionAggregate")
 class WikibaseSoftwareMinorVersionAggregateStrawberryModel(
     WikibaseSoftwareMidVersionAggregateStrawberryModel
 ):
@@ -126,7 +126,7 @@ class WikibaseSoftwareMinorVersionAggregateStrawberryModel(
         return sorted(temp.values(), key=lambda x: x.wikibase_count(), reverse=True)
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseSoftwareMajorVersionAggregate")
 class WikibaseSoftwareMajorVersionAggregateStrawberryModel(
     WikibaseSoftwareMidVersionAggregateStrawberryModel
 ):
@@ -154,7 +154,7 @@ class WikibaseSoftwareMajorVersionAggregateStrawberryModel(
         return sorted(temp.values(), key=lambda x: x.wikibase_count(), reverse=True)
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseSoftwareVersionDoubleAggregate")
 class WikibaseSoftwareVersionDoubleAggregateStrawberryModel:
     """Wikibase Software Version Aggregate"""
 

--- a/model/strawberry/output/observation/software_version/software_version_observation.py
+++ b/model/strawberry/output/observation/software_version/software_version_observation.py
@@ -12,7 +12,7 @@ from model.strawberry.output.observation.wikibase_observation import (
 )
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseSoftwareVersionObservation")
 class WikibaseSoftwareVersionObservationStrawberryModel(
     WikibaseObservationStrawberryModel
 ):

--- a/model/strawberry/output/observation/statistics/component/edit_stats.py
+++ b/model/strawberry/output/observation/statistics/component/edit_stats.py
@@ -7,7 +7,7 @@ from model.database import WikibaseStatisticsObservationModel
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseStatisticsEditsObservation")
 class WikibaseStatisticsEditsObservationStrawberryModel:
     """Wikibase Statistics Edits Data"""
 

--- a/model/strawberry/output/observation/statistics/component/files_stats.py
+++ b/model/strawberry/output/observation/statistics/component/files_stats.py
@@ -7,7 +7,7 @@ from model.database import WikibaseStatisticsObservationModel
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseStatisticsFilesObservation")
 class WikibaseStatisticsFilesObservationStrawberryModel:
     """Wikibase Statistics Files Data"""
 

--- a/model/strawberry/output/observation/statistics/component/pages_stats.py
+++ b/model/strawberry/output/observation/statistics/component/pages_stats.py
@@ -7,7 +7,7 @@ from model.database import WikibaseStatisticsObservationModel
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseStatisticsPagesObservation")
 class WikibaseStatisticsPagesObservationStrawberryModel:
     """Wikibase Statistics Pages Data"""
 

--- a/model/strawberry/output/observation/statistics/component/users_stats.py
+++ b/model/strawberry/output/observation/statistics/component/users_stats.py
@@ -6,7 +6,7 @@ from model.database import WikibaseStatisticsObservationModel
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseStatisticsUsersObservation")
 class WikibaseStatisticsUsersObservationStrawberryModel:
     """Wikibase Statistics User Data"""
 

--- a/model/strawberry/output/observation/statistics/wikibase_statistics_aggregate.py
+++ b/model/strawberry/output/observation/statistics/wikibase_statistics_aggregate.py
@@ -10,7 +10,7 @@ from model.strawberry.output.observation.statistics.component import (
 )
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseStatisticsAggregate")
 class WikibaseStatisticsAggregateStrawberryModel:
     """Aggregate Statistics"""
 

--- a/model/strawberry/output/observation/statistics/wikibase_statistics_observation.py
+++ b/model/strawberry/output/observation/statistics/wikibase_statistics_observation.py
@@ -15,7 +15,7 @@ from model.strawberry.output.observation.wikibase_observation import (
 )
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseStatisticsObservation")
 class WikibaseStatisticsObservationStrawberryModel(WikibaseObservationStrawberryModel):
     """Wikibase Statistics Data Observation"""
 

--- a/model/strawberry/output/observation/user/wikibase_user_aggregate.py
+++ b/model/strawberry/output/observation/user/wikibase_user_aggregate.py
@@ -5,7 +5,7 @@ import strawberry
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseUserAggregate")
 class WikibaseUserAggregateStrawberryModel:
     """Aggregate User"""
 

--- a/model/strawberry/output/observation/user/wikibase_user_group.py
+++ b/model/strawberry/output/observation/user/wikibase_user_group.py
@@ -5,7 +5,7 @@ import strawberry
 from model.database import WikibaseUserGroupModel
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseUserGroup")
 class WikibaseUserGroupStrawberryModel:
     """Wikibase User Group"""
 

--- a/model/strawberry/output/observation/user/wikibase_user_observation.py
+++ b/model/strawberry/output/observation/user/wikibase_user_observation.py
@@ -13,7 +13,7 @@ from model.strawberry.output.observation.wikibase_observation import (
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseUserObservation")
 class WikibaseUserObservationStrawberryModel(WikibaseObservationStrawberryModel):
     """Wikibase User Data Observation"""
 

--- a/model/strawberry/output/observation/user/wikibase_user_observation_group.py
+++ b/model/strawberry/output/observation/user/wikibase_user_observation_group.py
@@ -9,7 +9,7 @@ from model.strawberry.output.observation.user.wikibase_user_group import (
 from model.strawberry.scalars import BigInt
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseUserObservationGroup")
 class WikibaseUserObservationGroupStrawberryModel:
     """Wikibase Observed User Group"""
 

--- a/model/strawberry/output/observation/wikibase_observation.py
+++ b/model/strawberry/output/observation/wikibase_observation.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import strawberry
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseObservation")
 class WikibaseObservationStrawberryModel:
     """Wikibase Data Observation - ABSTRACT"""
 

--- a/model/strawberry/output/observation/wikibase_observation_set.py
+++ b/model/strawberry/output/observation/wikibase_observation_set.py
@@ -11,7 +11,7 @@ from model.strawberry.output.observation.wikibase_observation import (
 T = TypeVar("T", bound=WikibaseObservationStrawberryModel)
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseObservationSet")
 class WikibaseObservationSetStrawberryModel(Generic[T]):
     """Wikibase Observation Set"""
 

--- a/model/strawberry/output/wikibase.py
+++ b/model/strawberry/output/wikibase.py
@@ -25,7 +25,7 @@ from model.strawberry.output.wikibase_location import WikibaseLocationStrawberry
 from model.strawberry.output.wikibase_url_set import WikibaseURLSetStrawberryModel
 
 
-@strawberry.type
+@strawberry.type(name="Wikibase")
 class WikibaseStrawberryModel:
     """Wikibase Instance"""
 

--- a/model/strawberry/output/wikibase_language_set.py
+++ b/model/strawberry/output/wikibase_language_set.py
@@ -6,7 +6,7 @@ import strawberry
 from model.database import WikibaseModel
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseLanguageSet")
 class WikibaseLanguageSetStrawberryModel:
     """Wikibase Language Set"""
 
@@ -27,7 +27,7 @@ class WikibaseLanguageSetStrawberryModel:
         )
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseLanguageAggregate")
 class WikibaseLanguageAggregateStrawberryModel:
     """Wikibase Language Aggregate"""
 

--- a/model/strawberry/output/wikibase_location.py
+++ b/model/strawberry/output/wikibase_location.py
@@ -6,7 +6,7 @@ import strawberry
 from model.database import WikibaseModel
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseLocation")
 class WikibaseLocationStrawberryModel:
     """Wikibase Location"""
 

--- a/model/strawberry/output/wikibase_software.py
+++ b/model/strawberry/output/wikibase_software.py
@@ -8,7 +8,7 @@ from model.database import WikibaseSoftwareModel
 from model.enum.wikibase_software_type_enum import WikibaseSoftwareType
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseSoftware")
 class WikibaseSoftwareStrawberryModel:
     """Wikibase Software"""
 

--- a/model/strawberry/output/wikibase_url_set.py
+++ b/model/strawberry/output/wikibase_url_set.py
@@ -6,7 +6,7 @@ import strawberry
 from model.database import WikibaseModel
 
 
-@strawberry.type
+@strawberry.type(name="WikibaseURLSet")
 class WikibaseURLSetStrawberryModel:
     """Wikibase URL Set"""
 

--- a/tests/test_query/aggregation/software_version/software_version_aggregate_fragment.py
+++ b/tests/test_query/aggregation/software_version/software_version_aggregate_fragment.py
@@ -1,8 +1,8 @@
 """Software Version Aggregation Fragment"""
 
 SOFTWARE_VERSION_AGGREGATE_FRAGMENT = """
-fragment WikibaseSoftwareVersionAggregateStrawberryModelFragment
- on WikibaseSoftwareVersionAggregateStrawberryModel {
+fragment WikibaseSoftwareVersionAggregateFragment
+ on WikibaseSoftwareVersionAggregate {
   version
   versionDate
   versionHash
@@ -13,8 +13,8 @@ fragment WikibaseSoftwareVersionAggregateStrawberryModelFragment
 
 SOFTWARE_VERSION_DOUBLE_AGGREGATE_FRAGMENT = (
     """
-fragment WikibaseSoftwareVersionDoubleAggregateStrawberryModelPageFragment
- on WikibaseSoftwareVersionDoubleAggregateStrawberryModelPage {
+fragment WikibaseSoftwareVersionDoubleAggregatePageFragment
+ on WikibaseSoftwareVersionDoubleAggregatePage {
   meta {
     pageNumber
     pageSize
@@ -25,7 +25,7 @@ fragment WikibaseSoftwareVersionDoubleAggregateStrawberryModelPageFragment
     softwareName
     wikibaseCount
     versions {
-      ...WikibaseSoftwareVersionAggregateStrawberryModelFragment
+      ...WikibaseSoftwareVersionAggregateFragment
     }
     majorVersions {
       version
@@ -37,7 +37,7 @@ fragment WikibaseSoftwareVersionDoubleAggregateStrawberryModelPageFragment
           version
           wikibaseCount
           subVersions {
-            ...WikibaseSoftwareVersionAggregateStrawberryModelFragment
+            ...WikibaseSoftwareVersionAggregateFragment
           }
         }
       }

--- a/tests/test_query/aggregation/software_version/test_aggregate_extensions_query.py
+++ b/tests/test_query/aggregation/software_version/test_aggregate_extensions_query.py
@@ -16,7 +16,7 @@ AGGREGATE_EXTENSIONS_QUERY = (
     """
 query MyQuery($pageNumber: Int!, $pageSize: Int!) {
   aggregateExtensionPopularity(pageNumber: $pageNumber, pageSize: $pageSize) {
-    ...WikibaseSoftwareVersionDoubleAggregateStrawberryModelPageFragment
+    ...WikibaseSoftwareVersionDoubleAggregatePageFragment
   }
 }
 

--- a/tests/test_query/aggregation/software_version/test_aggregate_libraries_query.py
+++ b/tests/test_query/aggregation/software_version/test_aggregate_libraries_query.py
@@ -15,7 +15,7 @@ AGGREGATE_LIBRARIES_QUERY = (
     """
 query MyQuery($pageNumber: Int!, $pageSize: Int!) {
   aggregateLibraryPopularity(pageNumber: $pageNumber, pageSize: $pageSize) {
-    ...WikibaseSoftwareVersionDoubleAggregateStrawberryModelPageFragment
+    ...WikibaseSoftwareVersionDoubleAggregatePageFragment
   }
 }
 

--- a/tests/test_query/aggregation/software_version/test_aggregate_skins_query.py
+++ b/tests/test_query/aggregation/software_version/test_aggregate_skins_query.py
@@ -16,7 +16,7 @@ AGGREGATE_SKINS_QUERY = (
     """
 query MyQuery($pageNumber: Int!, $pageSize: Int!) {
   aggregateSkinPopularity(pageNumber: $pageNumber, pageSize: $pageSize) {
-    ...WikibaseSoftwareVersionDoubleAggregateStrawberryModelPageFragment
+    ...WikibaseSoftwareVersionDoubleAggregatePageFragment
   }
 }
 

--- a/tests/test_query/aggregation/software_version/test_aggregate_software_query.py
+++ b/tests/test_query/aggregation/software_version/test_aggregate_software_query.py
@@ -16,7 +16,7 @@ AGGREGATE_SOFTWARE_QUERY = (
     """
 query MyQuery($pageNumber: Int!, $pageSize: Int!) {
   aggregateSoftwarePopularity(pageNumber: $pageNumber, pageSize: $pageSize) {
-    ...WikibaseSoftwareVersionDoubleAggregateStrawberryModelPageFragment
+    ...WikibaseSoftwareVersionDoubleAggregatePageFragment
   }
 }
 

--- a/tests/test_query/wikibase/connectivity_obs/connectivity_fragment.py
+++ b/tests/test_query/wikibase/connectivity_obs/connectivity_fragment.py
@@ -1,7 +1,7 @@
 """Connectivity Observation Fragment"""
 
 WIKIBASE_CONNECTIVITY_OBSERVATION_FRAGMENT = """
-fragment WikibaseConnectivityObservationStrawberryModelFragment on WikibaseConnectivityObservationStrawberryModel {
+fragment WikibaseConnectivityObservationFragment on WikibaseConnectivityObservation {
   id
   observationDate
   returnedData

--- a/tests/test_query/wikibase/connectivity_obs/test_wikibase_connectivity_all_observations_query.py
+++ b/tests/test_query/wikibase/connectivity_obs/test_wikibase_connectivity_all_observations_query.py
@@ -19,7 +19,7 @@ query MyQuery($wikibaseId: Int!) {
     id
     connectivityObservations {
       allObservations {
-        ...WikibaseConnectivityObservationStrawberryModelFragment
+        ...WikibaseConnectivityObservationFragment
       }
     }
   }

--- a/tests/test_query/wikibase/connectivity_obs/test_wikibase_connectivity_most_recent_observation_query.py
+++ b/tests/test_query/wikibase/connectivity_obs/test_wikibase_connectivity_most_recent_observation_query.py
@@ -19,7 +19,7 @@ query MyQuery($wikibaseId: Int!) {
     id
     connectivityObservations {
       mostRecent {
-        ...WikibaseConnectivityObservationStrawberryModelFragment
+        ...WikibaseConnectivityObservationFragment
       }
     }
   }

--- a/tests/test_query/wikibase/log_obs/first_month/test_wikibase_log_first_month_all_observations_query.py
+++ b/tests/test_query/wikibase/log_obs/first_month/test_wikibase_log_first_month_all_observations_query.py
@@ -24,7 +24,7 @@ query MyQuery($wikibaseId: Int!) {
     logObservations {
       firstMonth {
         allObservations {
-          ...WikibaseLogMonthStrawberryModelFragment
+          ...WikibaseLogMonthFragment
         }
       }
     }

--- a/tests/test_query/wikibase/log_obs/first_month/test_wikibase_log_first_month_most_recent_observation_query.py
+++ b/tests/test_query/wikibase/log_obs/first_month/test_wikibase_log_first_month_most_recent_observation_query.py
@@ -24,7 +24,7 @@ query MyQuery($wikibaseId: Int!) {
     logObservations {
       firstMonth {
         mostRecent {
-          ...WikibaseLogMonthStrawberryModelFragment
+          ...WikibaseLogMonthFragment
         }
       }
     }

--- a/tests/test_query/wikibase/log_obs/last_month/test_wikibase_log_last_month_all_observations_query.py
+++ b/tests/test_query/wikibase/log_obs/last_month/test_wikibase_log_last_month_all_observations_query.py
@@ -24,7 +24,7 @@ query MyQuery($wikibaseId: Int!) {
     logObservations {
       lastMonth {
         allObservations {
-          ...WikibaseLogMonthStrawberryModelFragment
+          ...WikibaseLogMonthFragment
         }
       }
     }

--- a/tests/test_query/wikibase/log_obs/last_month/test_wikibase_log_last_month_most_recent_observation_query.py
+++ b/tests/test_query/wikibase/log_obs/last_month/test_wikibase_log_last_month_most_recent_observation_query.py
@@ -22,7 +22,7 @@ query MyQuery($wikibaseId: Int!) {
     logObservations {
       lastMonth {
         mostRecent {
-          ...WikibaseLogMonthStrawberryModelFragment
+          ...WikibaseLogMonthFragment
         }
       }
     }

--- a/tests/test_query/wikibase/log_obs/log_fragment.py
+++ b/tests/test_query/wikibase/log_obs/log_fragment.py
@@ -1,7 +1,7 @@
 """Log Observation Fragment"""
 
 WIKIBASE_LOG_OBSERVATION_FRAGMENT = """
-fragment WikibaseLogMonthStrawberryModelFragment on WikibaseLogMonthStrawberryModel {
+fragment WikibaseLogMonthFragment on WikibaseLogMonth {
   id
   observationDate
   returnedData

--- a/tests/test_query/wikibase/property_popularity_obs/property_popularity_fragment.py
+++ b/tests/test_query/wikibase/property_popularity_obs/property_popularity_fragment.py
@@ -1,7 +1,7 @@
 """Property Popularity Observation Fragment"""
 
 WIKIBASE_PROPERTY_POPULARITY_OBSERVATION_FRAGMENT = """
-fragment WikibasePropertyPopularityObservationStrawberryModelFragment on WikibasePropertyPopularityObservationStrawberryModel {
+fragment WikibasePropertyPopularityObservationFragment on WikibasePropertyPopularityObservation {
   id
   observationDate
   returnedData

--- a/tests/test_query/wikibase/property_popularity_obs/test_wikibase_property_popularity_all_observations_query.py
+++ b/tests/test_query/wikibase/property_popularity_obs/test_wikibase_property_popularity_all_observations_query.py
@@ -22,7 +22,7 @@ query MyQuery($wikibaseId: Int!) {
     id
     propertyPopularityObservations {
       allObservations {
-        ...WikibasePropertyPopularityObservationStrawberryModelFragment
+        ...WikibasePropertyPopularityObservationFragment
       }
     }
   }

--- a/tests/test_query/wikibase/property_popularity_obs/test_wikibase_property_popularity_most_recent_observation_query.py
+++ b/tests/test_query/wikibase/property_popularity_obs/test_wikibase_property_popularity_most_recent_observation_query.py
@@ -18,7 +18,7 @@ query MyQuery($wikibaseId: Int!) {
     id
     propertyPopularityObservations {
       mostRecent {
-        ...WikibasePropertyPopularityObservationStrawberryModelFragment
+        ...WikibasePropertyPopularityObservationFragment
       }
     }
   }

--- a/tests/test_query/wikibase/quantity_obs/quantity_fragment.py
+++ b/tests/test_query/wikibase/quantity_obs/quantity_fragment.py
@@ -1,7 +1,7 @@
 """Quantity Observation Fragment"""
 
 WIKIBASE_QUANTITY_OBSERVATION_FRAGMENT = """
-fragment WikibaseQuantityObservationStrawberryModelFragment on WikibaseQuantityObservationStrawberryModel {
+fragment WikibaseQuantityObservationFragment on WikibaseQuantityObservation {
   id
   observationDate
   returnedData

--- a/tests/test_query/wikibase/quantity_obs/test_wikibase_quantity_all_observations_query.py
+++ b/tests/test_query/wikibase/quantity_obs/test_wikibase_quantity_all_observations_query.py
@@ -16,7 +16,7 @@ query MyQuery($wikibaseId: Int!) {
     id
     quantityObservations {
       allObservations {
-        ...WikibaseQuantityObservationStrawberryModelFragment
+        ...WikibaseQuantityObservationFragment
       }
     }
   }

--- a/tests/test_query/wikibase/quantity_obs/test_wikibase_quantity_most_recent_observation_query.py
+++ b/tests/test_query/wikibase/quantity_obs/test_wikibase_quantity_most_recent_observation_query.py
@@ -16,7 +16,7 @@ query MyQuery($wikibaseId: Int!) {
     id
     quantityObservations {
       mostRecent {
-        ...WikibaseQuantityObservationStrawberryModelFragment
+        ...WikibaseQuantityObservationFragment
       }
     }
   }

--- a/tests/test_query/wikibase/software_version_obs/software_version_fragment.py
+++ b/tests/test_query/wikibase/software_version_obs/software_version_fragment.py
@@ -1,8 +1,8 @@
 """Software Version Observation Fragment"""
 
 WIKIBASE_SOFTWARE_VERSION_FRAGMENT = """
-fragment WikibaseSoftwareVersionStrawberryModelFragment
- on WikibaseSoftwareVersionStrawberryModel {
+fragment WikibaseSoftwareVersionFragment
+ on WikibaseSoftwareVersion {
   id
   softwareName
   version
@@ -14,13 +14,13 @@ fragment WikibaseSoftwareVersionStrawberryModelFragment
 
 WIKIBASE_SOFTWARE_VERSION_OBSERVATIONS_FRAGMENT = (
     """
-fragment WikibaseSoftwareVersionObservationStrawberryModelFragment
- on WikibaseSoftwareVersionObservationStrawberryModel {
+fragment WikibaseSoftwareVersionObservationFragment
+ on WikibaseSoftwareVersionObservation {
   id
   observationDate
   returnedData
   installedSoftware {
-    ...WikibaseSoftwareVersionStrawberryModelFragment
+    ...WikibaseSoftwareVersionFragment
   }
 }
 

--- a/tests/test_query/wikibase/software_version_obs/test_wikibase_software_version_all_observations_query.py
+++ b/tests/test_query/wikibase/software_version_obs/test_wikibase_software_version_all_observations_query.py
@@ -15,7 +15,7 @@ query MyQuery($wikibaseId: Int!) {
     id
     softwareVersionObservations {
       allObservations {
-        ...WikibaseSoftwareVersionObservationStrawberryModelFragment
+        ...WikibaseSoftwareVersionObservationFragment
       }
     }
   }

--- a/tests/test_query/wikibase/software_version_obs/test_wikibase_software_version_most_recent_observation_extensions_query.py
+++ b/tests/test_query/wikibase/software_version_obs/test_wikibase_software_version_most_recent_observation_extensions_query.py
@@ -23,7 +23,7 @@ query MyQuery($wikibaseId: Int!) {
         observationDate
         returnedData
         installedExtensions {
-          ...WikibaseSoftwareVersionStrawberryModelFragment
+          ...WikibaseSoftwareVersionFragment
         }
       }
     }

--- a/tests/test_query/wikibase/software_version_obs/test_wikibase_software_version_most_recent_observation_libraries_query.py
+++ b/tests/test_query/wikibase/software_version_obs/test_wikibase_software_version_most_recent_observation_libraries_query.py
@@ -22,7 +22,7 @@ query MyQuery($wikibaseId: Int!) {
         observationDate
         returnedData
         installedLibraries {
-          ...WikibaseSoftwareVersionStrawberryModelFragment
+          ...WikibaseSoftwareVersionFragment
         }
       }
     }

--- a/tests/test_query/wikibase/software_version_obs/test_wikibase_software_version_most_recent_observation_skins_query.py
+++ b/tests/test_query/wikibase/software_version_obs/test_wikibase_software_version_most_recent_observation_skins_query.py
@@ -22,7 +22,7 @@ query MyQuery($wikibaseId: Int!) {
         observationDate
         returnedData
         installedSkins {
-          ...WikibaseSoftwareVersionStrawberryModelFragment
+          ...WikibaseSoftwareVersionFragment
         }
       }
     }

--- a/tests/test_query/wikibase/software_version_obs/test_wikibase_software_version_most_recent_observation_software_query.py
+++ b/tests/test_query/wikibase/software_version_obs/test_wikibase_software_version_most_recent_observation_software_query.py
@@ -23,7 +23,7 @@ query MyQuery($wikibaseId: Int!) {
         observationDate
         returnedData
         installedSoftware {
-          ...WikibaseSoftwareVersionStrawberryModelFragment
+          ...WikibaseSoftwareVersionFragment
         }
       }
     }

--- a/tests/test_query/wikibase/statistics_obs/statistics_fragment.py
+++ b/tests/test_query/wikibase/statistics_obs/statistics_fragment.py
@@ -1,7 +1,7 @@
 """Statistics Observation Fragment"""
 
 WIKIBASE_STATISTICS_OBSERVATION_FRAGMENT = """
-fragment WikibaseStatisticsObservationStrawberryModelFragment on WikibaseStatisticsObservationStrawberryModel {
+fragment WikibaseStatisticsObservationFragment on WikibaseStatisticsObservation {
   id
   observationDate
   returnedData

--- a/tests/test_query/wikibase/statistics_obs/test_wikibase_statistics_all_observations_query.py
+++ b/tests/test_query/wikibase/statistics_obs/test_wikibase_statistics_all_observations_query.py
@@ -16,7 +16,7 @@ query MyQuery($wikibaseId: Int!) {
     id
     statisticsObservations {
       allObservations {
-        ...WikibaseStatisticsObservationStrawberryModelFragment
+        ...WikibaseStatisticsObservationFragment
       }
     }
   }

--- a/tests/test_query/wikibase/statistics_obs/test_wikibase_statistics_most_recent_observation_query.py
+++ b/tests/test_query/wikibase/statistics_obs/test_wikibase_statistics_most_recent_observation_query.py
@@ -16,7 +16,7 @@ query MyQuery($wikibaseId: Int!) {
     id
     statisticsObservations {
       mostRecent {
-        ...WikibaseStatisticsObservationStrawberryModelFragment
+        ...WikibaseStatisticsObservationFragment
       }
     }
   }

--- a/tests/test_query/wikibase/user_obs/test_wikibase_user_all_observations_query.py
+++ b/tests/test_query/wikibase/user_obs/test_wikibase_user_all_observations_query.py
@@ -20,7 +20,7 @@ query MyQuery($wikibaseId: Int!) {
     id
     userObservations {
       allObservations {
-        ...WikibaseUserObservationStrawberryModelFragment
+        ...WikibaseUserObservationFragment
       }
     }
   }

--- a/tests/test_query/wikibase/user_obs/test_wikibase_user_most_recent_observation_query.py
+++ b/tests/test_query/wikibase/user_obs/test_wikibase_user_most_recent_observation_query.py
@@ -16,7 +16,7 @@ query MyQuery($wikibaseId: Int!) {
     id
     userObservations {
       mostRecent {
-        ...WikibaseUserObservationStrawberryModelFragment
+        ...WikibaseUserObservationFragment
       }
     }
   }

--- a/tests/test_query/wikibase/user_obs/user_fragment.py
+++ b/tests/test_query/wikibase/user_obs/user_fragment.py
@@ -1,7 +1,7 @@
 """User Observation Fragment"""
 
 WIKIBASE_USER_OBSERVATION_FRAGMENT = """
-fragment WikibaseUserObservationStrawberryModelFragment on WikibaseUserObservationStrawberryModel {
+fragment WikibaseUserObservationFragment on WikibaseUserObservation {
   id
   observationDate
   returnedData


### PR DESCRIPTION
Define strawberry type names such that "StrawberryModel" is removed. It is universal across output, therefore should be removed for brevity's sake from the output. (It is really annoying to work with type names that long on the frontend.)

It is still important to distinguish within the code between database types and output types