### PR TITLE
Exclude Cloud from (most) Out of Date

### DIFF
--- a/fetch_data/out_of_date/get_out_of_date_wikibases.py
+++ b/fetch_data/out_of_date/get_out_of_date_wikibases.py
@@ -40,6 +40,7 @@ def get_wikibase_with_out_of_date_connectivity_obs_query() -> (
             or_(
                 # pylint: disable-next=singleton-comparison
                 WikibaseModel.wikibase_type == None,
+                WikibaseModel.wikibase_type != WikibaseType.CLOUD,
                 WikibaseModel.wikibase_type != WikibaseType.TEST,
             ),
             WikibaseModel.sparql_endpoint_url.has(WikibaseURLModel.id),
@@ -87,6 +88,7 @@ def get_wikibase_with_out_of_date_log_first_obs_query() -> Select[tuple[Wikibase
             or_(
                 # pylint: disable-next=singleton-comparison
                 WikibaseModel.wikibase_type == None,
+                WikibaseModel.wikibase_type != WikibaseType.CLOUD,
                 WikibaseModel.wikibase_type != WikibaseType.TEST,
             ),
             WikibaseModel.script_path.has(WikibaseURLModel.id),
@@ -135,6 +137,7 @@ def get_wikibase_with_out_of_date_log_last_obs_query() -> Select[tuple[WikibaseM
             or_(
                 # pylint: disable-next=singleton-comparison
                 WikibaseModel.wikibase_type == None,
+                WikibaseModel.wikibase_type != WikibaseType.CLOUD,
                 WikibaseModel.wikibase_type != WikibaseType.TEST,
             ),
             WikibaseModel.script_path.has(WikibaseURLModel.id),
@@ -185,6 +188,7 @@ def get_wikibase_with_out_of_date_property_popularity_obs_query() -> (
             or_(
                 # pylint: disable-next=singleton-comparison
                 WikibaseModel.wikibase_type == None,
+                WikibaseModel.wikibase_type != WikibaseType.CLOUD,
                 WikibaseModel.wikibase_type != WikibaseType.TEST,
             ),
             WikibaseModel.sparql_endpoint_url.has(WikibaseURLModel.id),
@@ -276,6 +280,12 @@ def get_wikibase_with_out_of_date_recent_changes_obs_query() -> (
     query = select(WikibaseModel).where(
         and_(
             WikibaseModel.checked,
+            or_(
+                # pylint: disable-next=singleton-comparison
+                WikibaseModel.wikibase_type == None,
+                WikibaseModel.wikibase_type != WikibaseType.CLOUD,
+                WikibaseModel.wikibase_type != WikibaseType.TEST,
+            ),
             WikibaseModel.script_path.has(WikibaseURLModel.id),
             not_(
                 WikibaseModel.recent_changes_observations.any(
@@ -321,6 +331,7 @@ def get_wikibase_with_out_of_date_software_obs_query() -> Select[tuple[WikibaseM
             or_(
                 # pylint: disable-next=singleton-comparison
                 WikibaseModel.wikibase_type == None,
+                WikibaseModel.wikibase_type != WikibaseType.CLOUD,
                 WikibaseModel.wikibase_type != WikibaseType.TEST,
             ),
             WikibaseModel.article_path.has(WikibaseURLModel.id),
@@ -366,6 +377,7 @@ def get_wikibase_with_out_of_date_stats_obs_query() -> Select[tuple[WikibaseMode
             or_(
                 # pylint: disable-next=singleton-comparison
                 WikibaseModel.wikibase_type == None,
+                WikibaseModel.wikibase_type != WikibaseType.CLOUD,
                 WikibaseModel.wikibase_type != WikibaseType.TEST,
             ),
             WikibaseModel.article_path.has(WikibaseURLModel.id),
@@ -411,6 +423,7 @@ def get_wikibase_with_out_of_date_user_obs_query() -> Select[tuple[WikibaseModel
             or_(
                 # pylint: disable-next=singleton-comparison
                 WikibaseModel.wikibase_type == None,
+                WikibaseModel.wikibase_type != WikibaseType.CLOUD,
                 WikibaseModel.wikibase_type != WikibaseType.TEST,
             ),
             WikibaseModel.script_path.has(WikibaseURLModel.id),


### PR DESCRIPTION
Just got word that we're only supposed to run external identifier metrics on cloud, not the rest of our metric suite. This excludes cloud instances from those data pulls.