### PR TITLE
fix: adjust db connection pool for long queries on toolforge

### DIFF
--- a/data/database_connection.py
+++ b/data/database_connection.py
@@ -9,9 +9,9 @@ from config import database_connection_string
 
 async_engine = create_async_engine(
     database_connection_string,
-    pool_size=5,  # default
-    max_overflow=10,  # default
-    timeout=120,  # default 30, but we need more time for big queries, toolforge is slow
+    pool_size=5,  # default 5
+    max_overflow=10,  # default 10
+    pool_timeout=120,  # default 30, but we need more time for big queries, toolforge is slow
 )
 
 async_session = sessionmaker(


### PR DESCRIPTION
We recently had the problem, that long and complex queries triggered the following exception:
```json
{
  "data": null,
  "errors": [
    {
      "message": "QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00 (Background on this error at: https://sqlalche.me/e/20/3o7r)",
      "locations": [
        {
          "line": 14,
          "column": 7
        }
      ],
      "path": [
        "wikibaseList",
        "data",
        418,
        "quantityObservations"
      ]
    }
  ]
}
```

Increasing the number of connection did not change the situation. Further testing revealed, that as soon as a query takes longer than 30 seconds, the exception is triggered. Increasing the connection timeout solves the problem.