### PR TITLE
feat: logging improvements

### DIFF
--- a/logger/extra_formatter.py
+++ b/logger/extra_formatter.py
@@ -6,6 +6,8 @@ import logging
 DEFAULT_ARGS = {
     "name",
     "msg",
+    "message",
+    "asctime",
     "args",
     "levelname",
     "levelno",
@@ -22,6 +24,7 @@ DEFAULT_ARGS = {
     "relativeCreated",
     "thread",
     "threadName",
+    "taskName",
     "processName",
     "process",
     "wikibase",
@@ -33,20 +36,21 @@ class OptionalExtraFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         """Format Record"""
-
-        base_fmt = "%(asctime)s | %(levelname)s | %(message)s"
-        wikibase_fmt = (
-            "%(asctime)s | %(levelname)s | wikibase %(wikibase)d | %(message)s"
-        )
+        
+        fmt = "%(asctime)s | "
 
         if "wikibase" in record.__dict__.keys():
-            fmt = wikibase_fmt
-        else:
-            fmt = base_fmt
+            fmt += "wikibase:%(wikibase)d | "
+
+        if "taskName" in record.__dict__.keys():
+            fmt += "%(taskName)s | "
+
+        fmt += "%(levelname)s | "
+        fmt += "%(message)s"
 
         for k in record.__dict__.keys():
             if k not in DEFAULT_ARGS:
-                fmt += f"\n\t{k}: {record.__dict__.get(k)}"
+                fmt += f" | {k}:{record.__dict__.get(k)}"
 
         self._style._fmt = fmt  # pylint: disable=protected-access
 

--- a/logger/extra_formatter.py
+++ b/logger/extra_formatter.py
@@ -36,7 +36,7 @@ class OptionalExtraFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         """Format Record"""
-        
+
         fmt = "%(asctime)s | "
 
         if "wikibase" in record.__dict__.keys():

--- a/logger/get_logger.py
+++ b/logger/get_logger.py
@@ -3,6 +3,7 @@
 import logging
 from logging.handlers import TimedRotatingFileHandler
 import os
+import sys
 
 from config import log_directory, log_level
 from logger.extra_formatter import OptionalExtraFormatter
@@ -35,3 +36,10 @@ file_error_handler = TimedRotatingFileHandler(
 file_error_handler.setLevel(logging.WARNING)
 file_error_handler.setFormatter(wikibase_formatter)
 logger.addHandler(file_error_handler)
+
+# debug level logs to stdout, no matter what log level is set
+# makes sure that you always see the logs in the console
+stdout_handler = logging.StreamHandler(sys.stdout)
+stdout_handler.setLevel(logging.DEBUG)
+stdout_handler.setFormatter(wikibase_formatter)
+logger.addHandler(stdout_handler)

--- a/settings.ini
+++ b/settings.ini
@@ -5,4 +5,5 @@ auth_token = local-auth-token
 database_connection_string = sqlite+aiosqlite:///data/wikibase-data.db
 
 [logging]
-log_level = INFO
+; written to {log_directory}/{log_level.lower()}/suite-scraper.log
+log_level = DEBUG


### PR DESCRIPTION
- makes the log format more concise and one-line so it can be `grep`'d easier
- adds debug logs to stdout, no matter what is set in the config so you can be sure to never miss messages on the terminal

```
app-1  |       INFO   Application startup complete.
app-1  | 2025-08-19 14:51:10,984 | wikibase:2 | Task-3 | DEBUG | Quantity: Attempting Observation
app-1  | 2025-08-19 14:51:10,984 | wikibase:2 | Task-3 | DEBUG | Fetching Wikibase
app-1  | 2025-08-19 14:51:11,048 | wikibase:2 | Task-3 | DEBUG | Retrieved Wikibase
app-1  | 2025-08-19 14:51:11,049 | wikibase:2 | Task-3 | INFO | Fetching Property Count
app-1  | 2025-08-19 14:51:11,875 | wikibase:2 | Task-3 | WARNING | QuantityDataError
```

