### PR TITLE
refactor: split docker-compose files

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,42 @@
+# Docker compose setup for running tests against the dev version of the app
+# Use with:
+#   UID=$(id -u) GID=$(id -g) docker compose -f docker-compose.yml -f docker-compose-test.yml up --build
+
+services:
+  # docker compose run --build test-not-data
+  # MAKE SURE TO RESET YOUR DATA WITH
+  # $ git checkout data/wikibase-test-data.db
+  test-not-data:
+    build: .
+    volumes:
+      - type: bind
+        source: .
+        target: /workspace
+    entrypoint:
+      - pytest
+    command:
+      - -m
+      - "not data"
+      - --cov=.
+      - --cov-report
+      - html:cov_html
+      - --order-dependencies
+    environment:
+      SETTINGS_FILE: test-settings.ini
+    user: "${UID}:${GID}"
+
+  # docker compose run --build test-data
+  test-data:
+    build: .
+    volumes:
+      - type: bind
+        source: .
+        target: /workspace
+    entrypoint:
+      - pytest
+    command:
+      - -m
+      - data
+    environment:
+      SETTINGS_FILE: test-settings.ini
+    user: "${UID}:${GID}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 # Docker compose setup for developing the app
 # Use with:
-#   docker compose up --build
+#   UID=$(id -u) GID=$(id -g) docker compose up --build
 
 services:
   app:
@@ -11,42 +11,4 @@ services:
         target: /workspace
     ports:
       - 8000:8000
-    user: "${UID}:${GID}"
-
-  # docker compose run --build test-not-data
-  # MAKE SURE TO RESET YOUR DATA WITH
-  # $ git checkout data/wikibase-test-data.db
-  test-not-data:
-    build: .
-    volumes:
-      - type: bind
-        source: .
-        target: /workspace
-    entrypoint:
-      - pytest
-    command:
-      - -m
-      - "not data"
-      - --cov=.
-      - --cov-report
-      - html:cov_html
-      - --order-dependencies
-    environment:
-      SETTINGS_FILE: test-settings.ini
-    user: "${UID}:${GID}"
-
-  # docker compose run --build test-data
-  test-data:
-    build: .
-    volumes:
-      - type: bind
-        source: .
-        target: /workspace
-    entrypoint:
-      - pytest
-    command:
-      - -m
-      - data
-    environment:
-      SETTINGS_FILE: test-settings.ini
     user: "${UID}:${GID}"


### PR DESCRIPTION
So we can run the dev stack also without tests