### PR TITLE
fix: csv export without tmp file

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@
 
 from contextlib import asynccontextmanager
 from typing import Optional
-from fastapi import BackgroundTasks, FastAPI
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 from strawberry.fastapi import GraphQLRouter
@@ -48,9 +48,7 @@ app.include_router(GraphQLRouter(schema=schema), prefix="/graphql")
 
 
 @app.get("/csv/metrics")
-async def metric_csv(
-    background_tasks: BackgroundTasks, authorization: Optional[str] = None
-):
+async def metric_csv(authorization: Optional[str] = None):
     """Quantity CSV"""
 
     try:
@@ -63,4 +61,4 @@ async def metric_csv(
     except AssertionError:
         return PlainTextResponse("Authorization Failed", 403)
 
-    return await export_metric_csv(background_tasks)
+    return await export_metric_csv()

--- a/export_csv/metric.py
+++ b/export_csv/metric.py
@@ -1,6 +1,5 @@
 """Quantity CSV"""
 
-from fastapi import BackgroundTasks
 from fastapi.responses import StreamingResponse
 from sqlalchemy import Select, and_, func, or_, select
 
@@ -17,7 +16,7 @@ from model.database import (
 from model.enum import WikibaseType, WikibaseURLType
 
 
-async def export_metric_csv(background_tasks: BackgroundTasks) -> StreamingResponse:
+async def export_metric_csv() -> StreamingResponse:
     """CSV with Requested Metrics"""
 
     query = get_metrics_query()
@@ -26,7 +25,6 @@ async def export_metric_csv(background_tasks: BackgroundTasks) -> StreamingRespo
         query=query,
         export_filename="metrics",
         index_col="wikibase_id",
-        background_tasks=background_tasks,
     )
 
 

--- a/export_csv/util.py
+++ b/export_csv/util.py
@@ -1,7 +1,7 @@
 """Utilities"""
 
 from typing import Optional
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response
 import pandas
 from sqlalchemy import Connection, Select
 
@@ -37,4 +37,4 @@ async def export_csv(
     del df
 
     headers = {"Content-Disposition": f'attachment; filename="{export_filename}.csv"'}
-    return StreamingResponse(csv, headers=headers, media_type="text/csv")
+    return Response(csv, headers=headers, media_type="text/csv")


### PR DESCRIPTION
Simplifying by removing the tmp file workaround.