### PR TITLE
feat: frontend cloud support

### DIFF
--- a/frontend/App.vue
+++ b/frontend/App.vue
@@ -55,18 +55,8 @@ function handleAdded() {
 					<div>
 						<h1 class="text-xl md:text-2xl font-semibold">Wikibase Metadata</h1>
 						<p class="text-sm token-text-subtle">
-							An initiative by Wikimedia Deutschland to map the self-hosted
-							Wikibase ecosystem.
-						</p>
-						<p class="text-sm token-text-subtle">
-							Find even more Wikibase instances on
-							<a
-								href="https://wikibase.cloud/"
-								target="_blank"
-								rel="noopener noreferrer"
-								aria-label="Wikibase Cloud"
-								>Wikibase Cloud</a
-							>.
+							An initiative by Wikimedia Deutschland to map the Wikibase
+							ecosystem
 						</p>
 					</div>
 				</div>

--- a/frontend/components/WikibaseList.vue
+++ b/frontend/components/WikibaseList.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { onMounted, ref, watch, computed } from "vue";
-import { CdxProgressBar, CdxButton, CdxIcon } from "@wikimedia/codex";
+import {
+	CdxProgressBar,
+	CdxButton,
+	CdxIcon,
+	CdxToggleSwitch,
+} from "@wikimedia/codex";
 import {
 	cdxIconRecentChanges,
 	cdxIconDatabase,
@@ -16,12 +21,15 @@ const props = defineProps<{ token: string | null; endpoint: string }>();
 const loading = ref(false);
 const error = ref<string | null>(null);
 const items = ref<Wikibase[]>([]);
+const includeCloud = ref(false);
 type SortKey = "edits" | "triples";
 const sortKey = ref<SortKey>("edits");
 const sortDir = ref<"asc" | "desc">("desc");
 
-// Single request (large page size)
-const PAGE_SIZE = 10000;
+// Paged loading state
+const totalPages = ref<number | null>(null);
+const loadedPages = ref<number>(0);
+const PAGE_SIZE = 100;
 
 const sortDefs: Array<{ key: SortKey; label: string; icon: any }> = [
 	{
@@ -78,11 +86,12 @@ function onSortClick(k: SortKey) {
 	}
 }
 
-function buildSingleQuery(pageSize: number) {
-	// Always exclude TEST and CLOUD instances
+function buildQuery(pageNumber: number, pageSize: number) {
+	const exclude = includeCloud.value ? "TEST" : "TEST, CLOUD";
 	return `
     query q {
-      wikibaseList(pageNumber: 1, pageSize: ${pageSize}, wikibaseFilter: { wikibaseType: { exclude: [TEST, CLOUD] } }) {
+      wikibaseList(pageNumber: ${pageNumber}, pageSize: ${pageSize}, wikibaseFilter: { wikibaseType: { exclude: [${exclude}] } }) {
+        meta { totalPages pageNumber pageSize }
         data {
           id
           urls {
@@ -123,29 +132,74 @@ function buildSingleQuery(pageSize: number) {
   `;
 }
 
+function buildMetaQuery(pageSize: number) {
+	const exclude = includeCloud.value ? "TEST" : "TEST, CLOUD";
+	return `
+    query qMeta {
+      wikibaseList(pageNumber: 1, pageSize: ${pageSize}, wikibaseFilter: { wikibaseType: { exclude: [${exclude}] } }) {
+        meta { totalPages pageNumber pageSize }
+      }
+    }
+  `;
+}
+
 async function load() {
 	if (!props.token) return;
 	loading.value = true;
 	error.value = null;
 	items.value = [];
+	totalPages.value = null;
+	loadedPages.value = 0;
 
 	try {
-		const res = await fetch(props.endpoint, {
+		// Cheap initial request to discover total pages only
+		const firstRes = await fetch(props.endpoint, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
 				authorization: `bearer ${props.token}`,
 			},
-			body: JSON.stringify({ query: buildSingleQuery(PAGE_SIZE) }),
+			body: JSON.stringify({ query: buildMetaQuery(PAGE_SIZE) }),
 			credentials: "omit",
 		});
-		if (!res.ok) throw new Error(`HTTP ${res.status}`);
-		const json = await res.json();
-		if (json.errors) {
-			throw new Error(json.errors?.[0]?.message || "GraphQL error");
+		if (!firstRes.ok) throw new Error(`HTTP ${firstRes.status}`);
+		const firstJson = await firstRes.json();
+		if (firstJson.errors) {
+			throw new Error(firstJson.errors?.[0]?.message || "GraphQL error");
 		}
-		const data = (json?.data?.wikibaseList?.data ?? []) as any[];
-		items.value = data.map((d: any) => Wikibase.from(d));
+		const firstPageMeta = firstJson?.data?.wikibaseList;
+		const total = Number(firstPageMeta?.meta?.totalPages ?? 0) || 0;
+		totalPages.value = total;
+		// No data fetched yet; start progress at 0
+		items.value = [];
+		loadedPages.value = 0;
+
+		// Fetch all pages in parallel while updating progress
+		if (total > 0) {
+			const pageNumbers = Array.from({ length: total }, (_, i) => i + 1);
+			const promises = pageNumbers.map(async (page) => {
+				const res = await fetch(props.endpoint, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						authorization: `bearer ${props.token}`,
+					},
+					body: JSON.stringify({ query: buildQuery(page, PAGE_SIZE) }),
+					credentials: "omit",
+				});
+				if (!res.ok) throw new Error(`HTTP ${res.status}`);
+				const json = await res.json();
+				if (json.errors) {
+					throw new Error(json.errors?.[0]?.message || "GraphQL error");
+				}
+				const pageData = (json?.data?.wikibaseList?.data ?? []) as any[];
+				// Append items for this page
+				items.value.push(...pageData.map((d: any) => Wikibase.from(d)));
+				// Increment loaded pages count
+				loadedPages.value += 1;
+			});
+			await Promise.all(promises);
+		}
 	} catch (e: any) {
 		error.value = e?.message || String(e);
 	} finally {
@@ -162,57 +216,75 @@ watch(
 		if (t) load();
 	},
 );
+
+watch(includeCloud, () => {
+	load();
+});
 </script>
 
 <template>
 	<section>
+		<div class="mb-3 flex items-center justify-end gap-8">
+			<div class="flex items-center gap-2 ml-4">
+				<CdxToggleSwitch
+					v-model="includeCloud"
+					aria-label="Include Wikibase Cloud instances"
+					:disabled="loading"
+				>
+					wikibase.cloud
+				</CdxToggleSwitch>
+			</div>
+			<div class="flex items-center gap-2">
+				<div class="hidden md:block">Sort by</div>
+				<div class="flex items-center">
+					<template v-for="def in sortDefs" :key="def.key">
+						<CdxButton
+							weight="quiet"
+							type="button"
+							:disabled="loading"
+							:class="[
+								'token-rounded focus-outline-progressive',
+								sortKey === def.key ? 'token-surface-3 token-border-all' : '',
+							]"
+							:aria-pressed="sortKey === def.key"
+							:title="
+								def.label +
+								(sortKey === def.key
+									? sortDir === 'asc'
+										? ' (ascending)'
+										: ' (descending)'
+									: '')
+							"
+							@click="onSortClick(def.key as SortKey)"
+						>
+							<span class="inline-flex items-center">
+								<CdxIcon :icon="def.icon" />
+								<CdxIcon
+									v-if="sortKey === def.key"
+									:icon="sortDir === 'asc' ? cdxIconArrowUp : cdxIconArrowDown"
+									size="small"
+									style="margin-left: var(--spacing-25)"
+								/>
+							</span>
+						</CdxButton>
+					</template>
+				</div>
+			</div>
+		</div>
 		<div v-if="loading" class="py-6">
 			<p class="mb-1 text-xs text-center token-text-subtle">
-				Loading known Wikibase instances…
+				Loading known Wikibase instances — this can take a while...
+				<span
+					v-if="totalPages != null"
+					class="mb-3 text-xs text-center token-text-subtle"
+				>
+					{{ ((loadedPages / totalPages) * 100).toFixed(0) }}%
+				</span>
 			</p>
 			<CdxProgressBar aria-label="Loading known Wikibase instances" />
 		</div>
 		<div v-else-if="error" class="token-text-destructive">{{ error }}</div>
 		<div v-else>
-			<div class="mb-3 flex items-center justify-end gap-8">
-				<div class="flex items-center gap-2">
-					<div class="hidden md:block">Sort by</div>
-					<div class="flex items-center">
-						<template v-for="def in sortDefs" :key="def.key">
-							<CdxButton
-								weight="quiet"
-								type="button"
-								:class="[
-									'token-rounded focus-outline-progressive',
-									sortKey === def.key ? 'token-surface-3 token-border-all' : '',
-								]"
-								:aria-pressed="sortKey === def.key"
-								:title="
-									def.label +
-									(sortKey === def.key
-										? sortDir === 'asc'
-											? ' (ascending)'
-											: ' (descending)'
-										: '')
-								"
-								@click="onSortClick(def.key as SortKey)"
-							>
-								<span class="inline-flex items-center">
-									<CdxIcon :icon="def.icon" />
-									<CdxIcon
-										v-if="sortKey === def.key"
-										:icon="
-											sortDir === 'asc' ? cdxIconArrowUp : cdxIconArrowDown
-										"
-										size="small"
-										style="margin-left: var(--spacing-25)"
-									/>
-								</span>
-							</CdxButton>
-						</template>
-					</div>
-				</div>
-			</div>
 			<div
 				class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
 			>


### PR DESCRIPTION
- adds a button to toggle view of wikibase cloud instances
- adds chunked loading of wikibase instances

This initiative is paused for now. Remaining issues:
- loading all cloud instances is quite slow
- cloud instances do not have "time to first value" and "recent changes" data
  - we cannot get the data from cloud as cloud installed a bot blocker