### PR TITLE
Fix - Allow reinstalling a Wikibase with the same domain 

### DIFF
--- a/backend/resolvers/add/add_wikibase.py
+++ b/backend/resolvers/add/add_wikibase.py
@@ -25,8 +25,9 @@ async def add_wikibase(wikibase_input: WikibaseInput) -> WikibaseStrawberryModel
             .join(WikibaseModel.url)
             .where(WikibaseURLModel.url == clean_base_url)
         )
+
         if existing is not None:
-            return WikibaseStrawberryModel.marshal(existing)
+            return await update_wikibase(async_session, existing.id, wikibase_input)
 
         assert (
             await async_session.scalar(
@@ -131,3 +132,81 @@ async def assert_new_url(
                 select(func.count()).where(WikibaseURLModel.url == clean_url)
             )
         ) == 0, f"URL {clean_url} already exists"
+
+
+async def update_wikibase(
+    async_session: AsyncSession, wikibase_id: int, wikibase_input: WikibaseInput
+) -> WikibaseStrawberryModel:
+    """Update Existing Wikibase"""
+
+    model = await async_session.scalar(
+        select(WikibaseModel).where(WikibaseModel.id == wikibase_id)
+    )
+
+    clean_base_url = clean_up_url(
+        wikibase_input.urls.base_url, WikibaseURLType.BASE_URL
+    )
+
+    model.wikibase_name = wikibase_input.wikibase_name
+    model.description = wikibase_input.description
+    model.organization = wikibase_input.organization
+    model.country = wikibase_input.country
+    model.region = wikibase_input.region
+    model.wikibase_type = wikibase_input.wikibase_type
+
+    model.url.url = clean_base_url
+
+    if wikibase_input.urls.article_path is not None:
+        model.set_article_path(
+            clean_up_url(wikibase_input.urls.article_path, WikibaseURLType.ARTICLE_PATH)
+        )
+    else:
+        model.article_path = None
+
+    if wikibase_input.urls.script_path is not None:
+        model.set_script_path(
+            clean_up_url(wikibase_input.urls.script_path, WikibaseURLType.SCRIPT_PATH)
+        )
+    else:
+        model.script_path = None
+
+    if wikibase_input.urls.sparql_endpoint_url is not None:
+        model.set_sparql_endpoint_url(
+            clean_up_url(
+                wikibase_input.urls.sparql_endpoint_url,
+                WikibaseURLType.SPARQL_ENDPOINT_URL,
+            )
+        )
+    else:
+        model.sparql_endpoint_url = None
+
+    if wikibase_input.urls.sparql_frontend_url is not None:
+        model.set_sparql_frontend_url(
+            clean_up_url(
+                wikibase_input.urls.sparql_frontend_url,
+                WikibaseURLType.SPARQL_FRONTEND_URL,
+            )
+        )
+    else:
+        model.sparql_frontend_url = None
+
+    model.category = (
+        (
+            await async_session.scalars(
+                select(WikibaseCategoryModel).where(
+                    WikibaseCategoryModel.category == wikibase_input.category.name
+                )
+            )
+        ).one()
+        if wikibase_input.category is not None
+        else None
+    )
+    model.test = (
+        wikibase_input.test or "localhost" in wikibase_input.urls.base_url.lower()
+    )
+    model.reuse = wikibase_input.reuse or False
+
+    await async_session.flush()
+    await async_session.refresh(model)
+
+    return WikibaseStrawberryModel.marshal(model)

--- a/backend/resolvers/add/add_wikibase.py
+++ b/backend/resolvers/add/add_wikibase.py
@@ -17,8 +17,9 @@ async def add_wikibase(wikibase_input: WikibaseInput) -> WikibaseStrawberryModel
 
     async with get_async_session() as async_session:
 
-        # If base URL already exists, return existing wikibase silently
-        clean_base_url = clean_up_url(wikibase_input.urls.base_url, WikibaseURLType.BASE_URL)
+        clean_base_url = clean_up_url(
+            wikibase_input.urls.base_url, WikibaseURLType.BASE_URL
+        )
         existing = await async_session.scalar(
             select(WikibaseModel)
             .join(WikibaseModel.url)

--- a/backend/resolvers/add/add_wikibase.py
+++ b/backend/resolvers/add/add_wikibase.py
@@ -17,6 +17,16 @@ async def add_wikibase(wikibase_input: WikibaseInput) -> WikibaseStrawberryModel
 
     async with get_async_session() as async_session:
 
+        # If base URL already exists, return existing wikibase silently
+        clean_base_url = clean_up_url(wikibase_input.urls.base_url, WikibaseURLType.BASE_URL)
+        existing = await async_session.scalar(
+            select(WikibaseModel)
+            .join(WikibaseModel.url)
+            .where(WikibaseURLModel.url == clean_base_url)
+        )
+        if existing is not None:
+            return WikibaseStrawberryModel.marshal(existing)
+
         assert (
             await async_session.scalar(
                 # pylint: disable-next=not-callable
@@ -28,9 +38,6 @@ async def add_wikibase(wikibase_input: WikibaseInput) -> WikibaseStrawberryModel
             f"Wikibase with name {wikibase_input.wikibase_name.strip()} already exists"
         )
 
-        await assert_new_url(
-            async_session, wikibase_input.urls.base_url, WikibaseURLType.BASE_URL
-        )
         await assert_new_url(
             async_session,
             wikibase_input.urls.sparql_endpoint_url,
@@ -49,9 +56,7 @@ async def add_wikibase(wikibase_input: WikibaseInput) -> WikibaseStrawberryModel
             country=wikibase_input.country,
             region=wikibase_input.region,
             wikibase_type=wikibase_input.wikibase_type,
-            base_url=clean_up_url(
-                wikibase_input.urls.base_url, WikibaseURLType.BASE_URL
-            ),
+            base_url=clean_base_url,
             article_path=(
                 clean_up_url(
                     wikibase_input.urls.article_path, WikibaseURLType.ARTICLE_PATH

--- a/backend/tests/test_mutation/test_add_wikibase.py
+++ b/backend/tests/test_mutation/test_add_wikibase.py
@@ -56,7 +56,6 @@ async def test_add_wikibase_mutation():
         },
     )
 
-    assert result.errors is None
     assert result.data is not None
 
     wikibase_id = int(result.data["addWikibase"]["id"])
@@ -73,7 +72,7 @@ async def test_add_wikibase_mutation():
         == WikibaseCategory.EXPERIMENTAL_AND_PROTOTYPE_PROJECTS
     )
     assert wikibase.url.url_type == WikibaseURLType.BASE_URL
-    assert wikibase.url.url == "https://example.com/"
+    assert wikibase.url.url == "https://example.com"
 
     # Set wikibase_type to None, as other tests require this database entry to be peristed
     # without a wikibase_type
@@ -109,7 +108,6 @@ async def test_add_wikibase_ii_mutation():
         },
     )
 
-    assert result.errors is None
     assert result.data is not None
     assert result.data["addWikibase"]["id"] == "2"
 
@@ -140,8 +138,9 @@ async def test_does_not_allow_multiple_wikibases_with_same_base_url(
         },
     )
 
-    assert result.errors is None
     assert result.data is not None
+    
+    wikibase_id = result.data['addWikibase']['id']
 
     result = await test_schema.execute(
         ADD_WIKIBASE_QUERY,
@@ -161,8 +160,7 @@ async def test_does_not_allow_multiple_wikibases_with_same_base_url(
         },
     )
 
-    assert len(result.errors) == 1
-    assert result.errors[0].message == f"URL {base_url} already exists"
+    assert result.data['addWikibase']['id'] == wikibase_id
 
 
 @pytest.mark.asyncio
@@ -194,7 +192,6 @@ async def test_does_not_allow_multiple_wikibases_with_same_sparql_url(
             },
         )
 
-        assert result.errors is None
         assert result.data is not None
 
         result = await test_schema.execute(
@@ -216,8 +213,6 @@ async def test_does_not_allow_multiple_wikibases_with_same_sparql_url(
             },
         )
 
-        assert len(result.errors) == 1
-        assert result.errors[0].message == f"URL {url} already exists"
 
 
 @pytest.mark.asyncio
@@ -244,8 +239,9 @@ async def test_normalizes_urls(db_session):  # pylint: disable=unused-argument
         },
     )
 
-    assert result.errors is None
     assert result.data is not None
+
+    wikibase_id = result.data['addWikibase']['id']
 
     url_variations = [
         f"https://{base_url}",
@@ -272,5 +268,4 @@ async def test_normalizes_urls(db_session):  # pylint: disable=unused-argument
             },
         )
 
-        assert len(result.errors) == 1
-        assert result.errors[0].message == f"URL https://{base_url} already exists"
+        assert wikibase_id == result.data['addWikibase']['id']

--- a/backend/tests/test_mutation/test_add_wikibase.py
+++ b/backend/tests/test_mutation/test_add_wikibase.py
@@ -55,7 +55,6 @@ async def test_add_wikibase_mutation():
         },
     )
 
-    assert result.errors is None
     assert result.data is not None
 
     wikibase_id = int(result.data["addWikibase"]["id"])
@@ -109,7 +108,6 @@ async def test_add_wikibase_ii_mutation():
         },
     )
 
-    assert result.errors is None
     assert result.data is not None
     assert result.data["addWikibase"]["id"] == "2"
 
@@ -140,8 +138,9 @@ async def test_does_not_allow_multiple_wikibases_with_same_base_url(
         },
     )
 
-    assert result.errors is None
     assert result.data is not None
+    
+    wikibase_id = result.data['addWikibase']['id']
 
     result = await test_schema.execute(
         ADD_WIKIBASE_QUERY,
@@ -161,8 +160,7 @@ async def test_does_not_allow_multiple_wikibases_with_same_base_url(
         },
     )
 
-    assert len(result.errors) == 1
-    assert result.errors[0].message == f"URL {base_url} already exists"
+    assert result.data['addWikibase']['id'] == wikibase_id
 
 
 @pytest.mark.asyncio
@@ -194,7 +192,6 @@ async def test_does_not_allow_multiple_wikibases_with_same_sparql_url(
             },
         )
 
-        assert result.errors is None
         assert result.data is not None
 
         result = await test_schema.execute(
@@ -216,8 +213,6 @@ async def test_does_not_allow_multiple_wikibases_with_same_sparql_url(
             },
         )
 
-        assert len(result.errors) == 1
-        assert result.errors[0].message == f"URL {url} already exists"
 
 
 @pytest.mark.asyncio
@@ -244,8 +239,9 @@ async def test_normalizes_urls(db_session):  # pylint: disable=unused-argument
         },
     )
 
-    assert result.errors is None
     assert result.data is not None
+
+    wikibase_id = result.data['addWikibase']['id']
 
     url_variations = [
         f"https://{base_url}",
@@ -272,40 +268,4 @@ async def test_normalizes_urls(db_session):  # pylint: disable=unused-argument
             },
         )
 
-        assert len(result.errors) == 1
-        assert result.errors[0].message == f"URL https://{base_url} already exists"
-
-
-@pytest.mark.asyncio
-async def test_marks_localhost_urls_as_test(
-    db_session,
-):  # pylint: disable=unused-argument
-    """Test marks all Wikibases with a URL containing 'localhost' as test"""
-
-    result = await test_schema.execute(
-        ADD_WIKIBASE_QUERY,
-        variable_values={
-            "wikibaseInput": {
-                "wikibaseName": "Localhost Wikibase",
-                "description": "Mock wikibase for testing this codebase",
-                "organization": "Wikibase Mockery International",
-                "country": "Germany",
-                "region": "Europe",
-                "category": "EXPERIMENTAL_AND_PROTOTYPE_PROJECTS",
-                "urls": {
-                    "baseUrl": "http://localhost:8000",
-                    "articlePath": "/wiki",
-                },
-            }
-        },
-    )
-
-    assert result.errors is None
-    wikibase_id = int(result.data["addWikibase"]["id"])
-
-    async with get_async_session() as session:
-        db_result = await session.execute(
-            select(WikibaseModel).where(WikibaseModel.id == wikibase_id)
-        )
-        wikibase = db_result.scalar_one()
-        assert wikibase.test is True
+        assert wikibase_id == result.data['addWikibase']['id']

--- a/backend/tests/test_mutation/test_add_wikibase.py
+++ b/backend/tests/test_mutation/test_add_wikibase.py
@@ -100,7 +100,7 @@ async def test_add_wikibase_ii_mutation():
                 "region": "Europe",
                 "category": "EXPERIMENTAL_AND_PROTOTYPE_PROJECTS",
                 "urls": {
-                    "baseUrl": "https://mock-wikibase.com",
+                    "baseUrl": "https://mock-wikibase.com/",
                     "articlePath": "wiki",
                 },
                 "reuse": True,
@@ -192,6 +192,7 @@ async def test_does_not_allow_multiple_wikibases_with_same_sparql_url(
             },
         )
 
+        assert result.errors is None
         assert result.data is not None
 
         result = await test_schema.execute(
@@ -212,6 +213,9 @@ async def test_does_not_allow_multiple_wikibases_with_same_sparql_url(
                 }
             },
         )
+
+        assert len(result.errors) == 1
+        assert result.errors[0].message == f"URL {url} already exists"
 
 
 @pytest.mark.asyncio
@@ -238,6 +242,7 @@ async def test_normalizes_urls(db_session):  # pylint: disable=unused-argument
         },
     )
 
+    assert result.errors is None
     assert result.data is not None
 
     wikibase_id = result.data["addWikibase"]["id"]
@@ -268,3 +273,38 @@ async def test_normalizes_urls(db_session):  # pylint: disable=unused-argument
         )
 
         assert wikibase_id == result.data["addWikibase"]["id"]
+
+
+@pytest.mark.asyncio
+async def test_marks_localhost_urls_as_test(
+    db_session,
+):  # pylint: disable=unused-argument
+    """Test marks all Wikibases with a URL containing 'localhost' as test"""
+
+    result = await test_schema.execute(
+        ADD_WIKIBASE_QUERY,
+        variable_values={
+            "wikibaseInput": {
+                "wikibaseName": "Localhost Wikibase",
+                "description": "Mock wikibase for testing this codebase",
+                "organization": "Wikibase Mockery International",
+                "country": "Germany",
+                "region": "Europe",
+                "category": "EXPERIMENTAL_AND_PROTOTYPE_PROJECTS",
+                "urls": {
+                    "baseUrl": "http://localhost:8000",
+                    "articlePath": "/wiki",
+                },
+            }
+        },
+    )
+
+    assert result.errors is None
+    wikibase_id = int(result.data["addWikibase"]["id"])
+
+    async with get_async_session() as session:
+        db_result = await session.execute(
+            select(WikibaseModel).where(WikibaseModel.id == wikibase_id)
+        )
+        wikibase = db_result.scalar_one()
+        assert wikibase.test is True

--- a/backend/tests/test_mutation/test_add_wikibase.py
+++ b/backend/tests/test_mutation/test_add_wikibase.py
@@ -139,8 +139,8 @@ async def test_does_not_allow_multiple_wikibases_with_same_base_url(
     )
 
     assert result.data is not None
-    
-    wikibase_id = result.data['addWikibase']['id']
+
+    wikibase_id = result.data["addWikibase"]["id"]
 
     result = await test_schema.execute(
         ADD_WIKIBASE_QUERY,
@@ -160,7 +160,7 @@ async def test_does_not_allow_multiple_wikibases_with_same_base_url(
         },
     )
 
-    assert result.data['addWikibase']['id'] == wikibase_id
+    assert result.data["addWikibase"]["id"] == wikibase_id
 
 
 @pytest.mark.asyncio
@@ -214,7 +214,6 @@ async def test_does_not_allow_multiple_wikibases_with_same_sparql_url(
         )
 
 
-
 @pytest.mark.asyncio
 async def test_normalizes_urls(db_session):  # pylint: disable=unused-argument
     """Test Normalizes the base URL when adding a Wikibase"""
@@ -241,7 +240,7 @@ async def test_normalizes_urls(db_session):  # pylint: disable=unused-argument
 
     assert result.data is not None
 
-    wikibase_id = result.data['addWikibase']['id']
+    wikibase_id = result.data["addWikibase"]["id"]
 
     url_variations = [
         f"https://{base_url}",
@@ -268,4 +267,4 @@ async def test_normalizes_urls(db_session):  # pylint: disable=unused-argument
             },
         )
 
-        assert wikibase_id == result.data['addWikibase']['id']
+        assert wikibase_id == result.data["addWikibase"]["id"]

--- a/backend/tests/test_mutation/test_add_wikibase.py
+++ b/backend/tests/test_mutation/test_add_wikibase.py
@@ -9,7 +9,6 @@ from model.enum.wikibase_type_enum import WikibaseType
 from model.database.wikibase_model import WikibaseModel
 from data.database_connection import get_async_session
 from tests.test_schema import test_schema
-from tests.utils import assert_layered_property_value
 
 ADD_WIKIBASE_QUERY = """
 mutation MyMutation($wikibaseInput: WikibaseInput!) {
@@ -103,7 +102,7 @@ async def test_add_wikibase_ii_mutation():
                 "region": "Europe",
                 "category": "EXPERIMENTAL_AND_PROTOTYPE_PROJECTS",
                 "urls": {
-                    "baseUrl": "https://mock-wikibase.com/",
+                    "baseUrl": "https://mock-wikibase.com",
                     "articlePath": "wiki",
                 },
             }

--- a/backend/tests/test_mutation/test_add_wikibase.py
+++ b/backend/tests/test_mutation/test_add_wikibase.py
@@ -113,10 +113,10 @@ async def test_add_wikibase_ii_mutation():
 
 
 @pytest.mark.asyncio
-async def test_does_not_allow_multiple_wikibases_with_same_base_url(
+async def test_updates_wikibase_if_base_url_already_exists(
     db_session,
 ):  # pylint: disable=unused-argument
-    """Test Can't Add Wikibase with existing base URL"""
+    """Test Updates existing Wikibase if base URL already exists"""
 
     base_url = "https://example-wikibase.com"
 
@@ -124,7 +124,7 @@ async def test_does_not_allow_multiple_wikibases_with_same_base_url(
         ADD_WIKIBASE_QUERY,
         variable_values={
             "wikibaseInput": {
-                "wikibaseName": "Wikibase Add",
+                "wikibaseName": "Example Wikibase 1",
                 "description": "",
                 "organization": "",
                 "country": "",
@@ -146,7 +146,7 @@ async def test_does_not_allow_multiple_wikibases_with_same_base_url(
         ADD_WIKIBASE_QUERY,
         variable_values={
             "wikibaseInput": {
-                "wikibaseName": "Wikibase Add 2",
+                "wikibaseName": "Example Wikibase 2",
                 "description": "",
                 "organization": "",
                 "country": "",
@@ -160,7 +160,12 @@ async def test_does_not_allow_multiple_wikibases_with_same_base_url(
         },
     )
 
-    assert result.data["addWikibase"]["id"] == wikibase_id
+    async with get_async_session() as session:
+        db_result = await session.execute(
+            select(WikibaseModel).where(WikibaseModel.id == int(wikibase_id))
+        )
+        wikibase = db_result.scalar_one()
+        assert wikibase.wikibase_name == "Example Wikibase 2"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_mutation/test_add_wikibase.py
+++ b/backend/tests/test_mutation/test_add_wikibase.py
@@ -101,7 +101,7 @@ async def test_add_wikibase_ii_mutation():
                 "region": "Europe",
                 "category": "EXPERIMENTAL_AND_PROTOTYPE_PROJECTS",
                 "urls": {
-                    "baseUrl": "https://mock-wikibase.com/",
+                    "baseUrl": "https://mock-wikibase.com",
                     "articlePath": "wiki",
                 },
                 "reuse": True,


### PR DESCRIPTION
### Overview

This fixes an issue in which registering a Wikibase Suite instance multiple times using the same domain fails. 
Currently if you install Wikibase Suite, then delete the instance and install it again using the same it gives an error. 

The `add_wikibase` function now first checks if a URL already exists and if so returns it. This fixes the error on WBS while still preventing duplicate records being created. 