### PR TITLE
feat: Reuse Flag

### DIFF
--- a/backend/alembic/versions/4fc740902451_reuse_wikibase.py
+++ b/backend/alembic/versions/4fc740902451_reuse_wikibase.py
@@ -1,0 +1,30 @@
+"""Reuse Wikibase
+
+Revision ID: 4fc740902451
+Revises: 67a5973d5ef4
+Create Date: 2026-05-07 06:01:24.241374
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "4fc740902451"
+down_revision: Union[str, Sequence[str], None] = "67a5973d5ef4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("wikibase") as batch_op:
+        batch_op.add_column(sa.Column("reuse", sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("wikibase") as batch_op:
+        batch_op.drop_column("reuse")

--- a/backend/export_csv/metric.py
+++ b/backend/export_csv/metric.py
@@ -185,6 +185,7 @@ def get_metrics_query() -> Select:
         select(
             filtered_wikibase_subquery.c.id.label("wikibase_id"),
             filtered_wikibase_subquery.c.wb_type.label("wikibase_type"),
+            filtered_wikibase_subquery.c.reuse,
             WikibaseURLModel.url.label("base_url"),
             most_recent_successful_quantity_obs.c.date.label(
                 "quantity_observation_date"

--- a/backend/model/database/wikibase_model.py
+++ b/backend/model/database/wikibase_model.py
@@ -76,6 +76,9 @@ class WikibaseModel(ModelBase):
     test: Mapped[bool] = mapped_column("test", Boolean, nullable=False)
     """Test Wikibase?"""
 
+    reuse: Mapped[Optional[bool]] = mapped_column("reuse", Boolean, nullable=True)
+    """Display Wikibase"""
+
     # LANGUAGES
     languages: Mapped[list[WikibaseLanguageModel]] = relationship(
         "WikibaseLanguageModel",

--- a/backend/model/database/wikibase_model.py
+++ b/backend/model/database/wikibase_model.py
@@ -335,6 +335,7 @@ class WikibaseModel(ModelBase):
         self.country = country
         self.region = region
         self.checked = False
+        self.reuse = False
         self.test = False
         self.wikibase_type = wikibase_type
 

--- a/backend/model/strawberry/input/wikibase_filter_input.py
+++ b/backend/model/strawberry/input/wikibase_filter_input.py
@@ -17,5 +17,5 @@ class WikibaseTypeInput:
 class WikibaseFilterInput:
     """Filter Wikibases"""
 
-    wikibase_type: Optional[WikibaseTypeInput]
+    wikibase_type: Optional[WikibaseTypeInput] = None
     ignore_reuse: Optional[bool] = None

--- a/backend/model/strawberry/input/wikibase_filter_input.py
+++ b/backend/model/strawberry/input/wikibase_filter_input.py
@@ -18,3 +18,4 @@ class WikibaseFilterInput:
     """Filter Wikibases"""
 
     wikibase_type: Optional[WikibaseTypeInput]
+    ignore_reuse: Optional[bool]

--- a/backend/model/strawberry/input/wikibase_filter_input.py
+++ b/backend/model/strawberry/input/wikibase_filter_input.py
@@ -18,4 +18,4 @@ class WikibaseFilterInput:
     """Filter Wikibases"""
 
     wikibase_type: Optional[WikibaseTypeInput]
-    ignore_reuse: Optional[bool]
+    ignore_reuse: Optional[bool] = None

--- a/backend/model/strawberry/input/wikibase_input.py
+++ b/backend/model/strawberry/input/wikibase_input.py
@@ -3,9 +3,8 @@
 from typing import Optional
 import strawberry
 
-from model.enum.wikibase_category_enum import WikibaseCategory
+from model.enum import WikibaseCategory, WikibaseType
 from model.strawberry.input.wikibase_url_input import WikibaseURLSetInput
-from model.enum.wikibase_type_enum import WikibaseType
 
 
 @strawberry.input
@@ -25,6 +24,8 @@ class WikibaseInput:
     category: Optional[WikibaseCategory] = None
 
     test: Optional[bool] = False
+
+    reuse: Optional[bool] = False
 
     urls: WikibaseURLSetInput
 

--- a/backend/model/strawberry/mutation_breakout/upsert_wikibase_mutation.py
+++ b/backend/model/strawberry/mutation_breakout/upsert_wikibase_mutation.py
@@ -15,6 +15,7 @@ from resolvers import (
     remove_wikibase_language,
     remove_wikibase_url,
     update_wikibase_primary_language,
+    update_wikibase_reuse_flag,
     update_wikibase_type,
     upsert_wikibase_url,
 )
@@ -58,6 +59,13 @@ class UpsertWikibaseMutation:
 
         authenticate(info)
         return await remove_wikibase_url(wikibase_id, url_type)
+
+    @strawberry.mutation(description="Set Reuse Flag for Wikibase")
+    async def set_reuse_flag(self, info: Info, wikibase_id: int, reuse: bool) -> bool:
+        """Set Reuse Flag for Wikibase"""
+
+        authenticate(info)
+        return await update_wikibase_reuse_flag(wikibase_id, reuse)
 
     @strawberry.mutation(
         description="Update the list of known Wikibase Cloud instances from API"

--- a/backend/resolvers/__init__.py
+++ b/backend/resolvers/__init__.py
@@ -23,6 +23,7 @@ from resolvers.update import (
     remove_wikibase_url,
     set_extension_wbs_bundled,
     update_wikibase_primary_language,
+    update_wikibase_reuse_flag,
     update_wikibase_type,
     upsert_wikibase_url,
 )

--- a/backend/resolvers/add/add_wikibase.py
+++ b/backend/resolvers/add/add_wikibase.py
@@ -95,6 +95,8 @@ async def add_wikibase(wikibase_input: WikibaseInput) -> WikibaseStrawberryModel
             if wikibase_input.category is not None
             else None
         )
+        model.test = wikibase_input.test
+        model.reuse = wikibase_input.reuse or False
 
         async_session.add(model)
 

--- a/backend/resolvers/update/__init__.py
+++ b/backend/resolvers/update/__init__.py
@@ -4,6 +4,7 @@ from resolvers.update.merge_software import merge_software_by_id
 from resolvers.update.set_extension_wbs_bundled import set_extension_wbs_bundled
 from resolvers.update.update_missing_script_paths import update_missing_script_paths
 from resolvers.update.update_missing_sparql_urls import update_missing_sparql_urls
+from resolvers.update.update_wikibase_flag import update_wikibase_reuse_flag
 from resolvers.update.update_wikibase_language import (
     add_wikibase_language,
     remove_wikibase_language,

--- a/backend/resolvers/update/update_wikibase_flag.py
+++ b/backend/resolvers/update/update_wikibase_flag.py
@@ -1,0 +1,22 @@
+"""Update Wikibase Reuse Flag"""
+
+from data.database_connection import get_async_session
+from fetch_data.utils import get_wikibase_from_database
+from logger import logger
+
+
+async def update_wikibase_reuse_flag(wikibase_id: int, reuse: bool) -> bool:
+    """Update Wikibase Reuse Flag"""
+
+    logger.info(f"Setting Reuse Flag: {reuse}", extra={"wikibase": wikibase_id})
+
+    async with get_async_session() as async_session:
+        wikibase = await get_wikibase_from_database(async_session, wikibase_id)
+        wikibase.reuse = reuse
+
+        await async_session.commit()
+
+    async with get_async_session() as async_session:
+        wikibase = await get_wikibase_from_database(async_session, wikibase_id)
+
+        return wikibase.reuse == reuse

--- a/backend/resolvers/util/get_filtered_wikibase_query.py
+++ b/backend/resolvers/util/get_filtered_wikibase_query.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 
-from sqlalchemy import Select, or_, select
+from sqlalchemy import Select, and_, or_, select
 
 from model.database import WikibaseModel
 from model.enum import WikibaseType
@@ -15,8 +15,12 @@ def get_filtered_wikibase_query(
     """Filtered list of Wikibases"""
 
     query = select(WikibaseModel).where(WikibaseModel.checked)
+
     if wikibase_filter is None:
-        return query
+        return query.where(WikibaseModel.reuse)
+
+    if not wikibase_filter.ignore_reuse:
+        query = query.where(WikibaseModel.reuse)
 
     if wikibase_filter.wikibase_type is not None:
         if (

--- a/backend/resolvers/util/get_filtered_wikibase_query.py
+++ b/backend/resolvers/util/get_filtered_wikibase_query.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 
-from sqlalchemy import Select, and_, or_, select
+from sqlalchemy import Select, or_, select
 
 from model.database import WikibaseModel
 from model.enum import WikibaseType

--- a/backend/tests/test_export_csv/test_export_metrics_csv.py
+++ b/backend/tests/test_export_csv/test_export_metrics_csv.py
@@ -9,6 +9,7 @@ EXPECTED_HEADER_ROW = ",".join(
     [
         "wikibase_id",
         "wikibase_type",
+        "reuse",
         "base_url",
         "quantity_observation_date",
         "total_items",
@@ -37,6 +38,7 @@ EXPECTED_HEADER_ROW = ",".join(
 EXPECTED_PATTERN_LIST = [
     re.compile(r"\d+"),
     re.compile(r"(WikibaseType\.(CLOUD|OTHER|SUITE)|)"),
+    re.compile(r"(True|False|)"),
     re.compile(r"https?://[a-z0-9\-_.\?=/]+"),
     # Quantity
     re.compile(r"(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d.\d+\+00:00|)"),

--- a/backend/tests/test_mutation/test_add_wikibase.py
+++ b/backend/tests/test_mutation/test_add_wikibase.py
@@ -50,6 +50,7 @@ async def test_add_wikibase_mutation():
                     "sparqlEndpointUrl": "https://query.example.com/sparql-wrong",
                     "sparqlFrontendUrl": "https://query.example.com",
                 },
+                "reuse": True,
             }
         },
     )

--- a/backend/tests/test_mutation/test_add_wikibase.py
+++ b/backend/tests/test_mutation/test_add_wikibase.py
@@ -104,6 +104,7 @@ async def test_add_wikibase_ii_mutation():
                     "baseUrl": "https://mock-wikibase.com/",
                     "articlePath": "wiki",
                 },
+                "reuse": True,
             }
         },
     )

--- a/backend/tests/test_mutation/test_add_wikibase.py
+++ b/backend/tests/test_mutation/test_add_wikibase.py
@@ -3,13 +3,10 @@
 
 import pytest
 from sqlalchemy import select
-from model.enum.wikibase_url_type_enum import WikibaseURLType
-from model.enum.wikibase_category_enum import WikibaseCategory
-from model.enum.wikibase_type_enum import WikibaseType
-from model.database.wikibase_model import WikibaseModel
+from model.enum import WikibaseCategory, WikibaseType, WikibaseURLType
+from model.database import WikibaseModel
 from data.database_connection import get_async_session
 from tests.test_schema import test_schema
-from tests.utils import assert_layered_property_value
 
 ADD_WIKIBASE_QUERY = """
 mutation MyMutation($wikibaseInput: WikibaseInput!) {

--- a/backend/tests/test_mutation/test_add_wikibase.py
+++ b/backend/tests/test_mutation/test_add_wikibase.py
@@ -74,7 +74,7 @@ async def test_add_wikibase_mutation():
         == WikibaseCategory.EXPERIMENTAL_AND_PROTOTYPE_PROJECTS
     )
     assert wikibase.url.url_type == WikibaseURLType.BASE_URL
-    assert wikibase.url.url == "https://example.com/"
+    assert wikibase.url.url == "https://example.com"
 
     # Set wikibase_type to None, as other tests require this database entry to be peristed
     # without a wikibase_type

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -64,11 +64,12 @@ async def test_set_wikibase_reuse_false():
     before_adding_reuse_true_ids = {
         int(w["id"]) for w in before_adding_result.data["filtered"]["data"]
     }
+    affecting_id = before_adding_reuse_true_ids.pop()
 
     update_result = await test_schema.execute(
         UPDATE_WIKIBASE_REUSE_MUTATION,
         variable_values={
-            "wikibaseId": before_adding_reuse_true_ids.pop(),
+            "wikibaseId": affecting_id,
             "reuse": False,
         },
         context_value=get_mock_context("test-auth-token"),
@@ -85,9 +86,15 @@ async def test_set_wikibase_reuse_false():
     assert_layered_property_value(
         after_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=1
     )
+    assert affecting_id not in [
+        int(w["id"]) for w in after_adding_result.data["filtered"]["data"]
+    ]
     assert_layered_property_value(
         after_adding_result.data, ["unfiltered", "meta", "totalCount"], expected_value=3
     )
+    assert affecting_id in [
+        int(w["id"]) for w in after_adding_result.data["unfiltered"]["data"]
+    ]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -69,7 +69,7 @@ async def test_set_wikibase_reuse_false():
         UPDATE_WIKIBASE_REUSE_MUTATION,
         variable_values={
             "wikibaseId": before_adding_reuse_true_ids.pop(),
-            "reuse": True,
+            "reuse": False,
         },
         context_value=get_mock_context("test-auth-token"),
     )

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -16,7 +16,7 @@ query PageWikibases {
         id
     }
   }
-  unfiltered: wikibaseList(pageNumber: 1, pageSize: 1, wikibaseFilter: { ignoreReuse:True } ) {
+  unfiltered: wikibaseList(pageNumber: 1, pageSize: 1, wikibaseFilter: { ignoreReuse: true } ) {
     meta {
       totalCount
     }

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -40,6 +40,58 @@ mutation MyMutation($wikibaseId: Int!, $reuse: Boolean!) {
 @pytest.mark.asyncio
 @pytest.mark.mutation
 @pytest.mark.dependency(
+    name="wikibase-set-reuse-false",
+    depends=["transform-cloud-instance"],
+)
+async def test_set_wikibase_reuse_false():
+    """Set Wikibase Reuse False"""
+
+    before_adding_result = await test_schema.execute(
+        WIKIBASE_FILTERED_AND_UNFILTERED_QUERY
+    )
+    assert before_adding_result.errors is None
+    assert before_adding_result.data is not None
+    assert_layered_property_value(
+        before_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=2
+    )
+    assert_layered_property_value(
+        before_adding_result.data,
+        ["unfiltered", "meta", "totalCount"],
+        expected_value=3,
+    )
+
+    before_adding_reuse_true_ids = {
+        int(w["id"]) for w in before_adding_result.data["filtered"]["data"]
+    }
+
+    update_result = await test_schema.execute(
+        UPDATE_WIKIBASE_REUSE_MUTATION,
+        variable_values={
+            "wikibaseId": before_adding_reuse_true_ids.pop(),
+            "reuse": True,
+        },
+        context_value=get_mock_context("test-auth-token"),
+    )
+    assert update_result.errors is None
+    assert update_result.data is not None
+    assert update_result.data["setReuseFlag"] is True
+
+    after_adding_result = await test_schema.execute(
+        WIKIBASE_FILTERED_AND_UNFILTERED_QUERY
+    )
+    assert after_adding_result.errors is None
+    assert after_adding_result.data is not None
+    assert_layered_property_value(
+        after_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=1
+    )
+    assert_layered_property_value(
+        after_adding_result.data, ["unfiltered", "meta", "totalCount"], expected_value=3
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.mutation
+@pytest.mark.dependency(
     name="wikibase-set-reuse-true",
     depends=["transform-cloud-instance", "wikibase-set-reuse-false"],
     scope="session",
@@ -152,56 +204,4 @@ async def test_set_cloud_wikibase_reuse_true():
         after_adding_result.data,
         ["unfiltered", "meta", "totalCount"],
         expected_value=11,
-    )
-
-
-@pytest.mark.asyncio
-@pytest.mark.mutation
-@pytest.mark.dependency(
-    name="wikibase-set-reuse-false",
-    depends=["transform-cloud-instance"],
-)
-async def test_set_wikibase_reuse_false():
-    """Set Wikibase Reuse False"""
-
-    before_adding_result = await test_schema.execute(
-        WIKIBASE_FILTERED_AND_UNFILTERED_QUERY
-    )
-    assert before_adding_result.errors is None
-    assert before_adding_result.data is not None
-    assert_layered_property_value(
-        before_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=2
-    )
-    assert_layered_property_value(
-        before_adding_result.data,
-        ["unfiltered", "meta", "totalCount"],
-        expected_value=3,
-    )
-
-    before_adding_reuse_true_ids = {
-        int(w["id"]) for w in before_adding_result.data["filtered"]["data"]
-    }
-
-    update_result = await test_schema.execute(
-        UPDATE_WIKIBASE_REUSE_MUTATION,
-        variable_values={
-            "wikibaseId": before_adding_reuse_true_ids.pop(),
-            "reuse": True,
-        },
-        context_value=get_mock_context("test-auth-token"),
-    )
-    assert update_result.errors is None
-    assert update_result.data is not None
-    assert update_result.data["setReuseFlag"] is True
-
-    after_adding_result = await test_schema.execute(
-        WIKIBASE_FILTERED_AND_UNFILTERED_QUERY
-    )
-    assert after_adding_result.errors is None
-    assert after_adding_result.data is not None
-    assert_layered_property_value(
-        after_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=1
-    )
-    assert_layered_property_value(
-        after_adding_result.data, ["unfiltered", "meta", "totalCount"], expected_value=3
     )

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -65,6 +65,7 @@ async def test_set_wikibase_reuse_true():
     before_adding_reuse_false_ids = (
         before_adding_reuse_all_ids - before_adding_reuse_true_ids
     )
+    assert len(before_adding_reuse_false_ids) == 1
 
     for wiki_id in before_adding_reuse_false_ids:
         update_result = await test_schema.execute(
@@ -80,10 +81,10 @@ async def test_set_wikibase_reuse_true():
     assert after_adding_result.errors is None
     assert after_adding_result.data is not None
     assert_layered_property_value(
-        after_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=2
+        after_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=3
     )
     assert_layered_property_value(
-        after_adding_result.data, ["unfiltered", "meta", "totalCount"], expected_value=2
+        after_adding_result.data, ["unfiltered", "meta", "totalCount"], expected_value=3
     )
 
 

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -38,7 +38,7 @@ mutation MyMutation($wikibaseId: Int!, $reuse: Boolean!) {
 @pytest.mark.mutation
 @pytest.mark.dependency(
     name="wikibase-set-reuse-true",
-    depends=["add-wikibase", "transform-cloud-instances"],
+    depends=["transform-cloud-instance"],
     scope="session",
 )
 async def test_set_wikibase_reuse_true():

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -1,0 +1,108 @@
+# pylint: disable=redefined-outer-name
+"""Test Update Wikibase Reuse Flag"""
+
+import pytest
+
+from tests.test_schema import test_schema
+from tests.utils import assert_layered_property_value, get_mock_context
+
+WIKIBASE_COUNT_QUERY = """
+query PageWikibases {
+  filtered: wikibaseList(pageNumber: 1, pageSize: 1) {
+    meta {
+      totalCount
+    }
+  }
+  unfiltered: wikibaseList(pageNumber: 1, pageSize: 1, wikibaseFilter: { ignoreReuse:True } ) {
+    meta {
+      totalCount
+    }
+  }
+}
+"""
+
+UPDATE_WIKIBASE_REUSE_MUTATION = """
+mutation MyMutation($wikibaseId: Int!, $reuse: Boolean!) {
+  setReuseFlag(wikibaseId: $wikibaseId, reuse: $reuse)
+}
+"""
+
+
+@pytest.mark.asyncio
+@pytest.mark.mutation
+@pytest.mark.dependency(
+    name="wikibase-set-reuse-true", depends=["add-wikibase"], scope="session"
+)
+async def test_set_wikibase_reuse_true():
+    """Set Wikibase Reuse True"""
+
+    before_adding_result = await test_schema.execute(WIKIBASE_COUNT_QUERY)
+    assert before_adding_result.errors is None
+    assert before_adding_result.data is not None
+    assert_layered_property_value(
+        before_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=1
+    )
+    assert_layered_property_value(
+        before_adding_result.data,
+        ["unfiltered", "meta", "totalCount"],
+        expected_value=1,
+    )
+
+    update_result = await test_schema.execute(
+        UPDATE_WIKIBASE_REUSE_MUTATION,
+        variable_values={"wikibaseId": 1, "reuse": True},
+        context_value=get_mock_context("test-auth-token"),
+    )
+    assert update_result.errors is None
+    assert update_result.data is not None
+    assert update_result.data["setReuseFlag"] is True
+
+    after_adding_result = await test_schema.execute(WIKIBASE_COUNT_QUERY)
+    assert after_adding_result.errors is None
+    assert after_adding_result.data is not None
+    assert_layered_property_value(
+        after_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=1
+    )
+    assert_layered_property_value(
+        after_adding_result.data, ["unfiltered", "meta", "totalCount"], expected_value=1
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.mutation
+@pytest.mark.dependency(
+    name="wikibase-set-reuse-false", depends=["add-wikibase"], scope="session"
+)
+async def test_set_wikibase_reuse_false():
+    """Set Wikibase Reuse False"""
+
+    before_adding_result = await test_schema.execute(WIKIBASE_COUNT_QUERY)
+    assert before_adding_result.errors is None
+    assert before_adding_result.data is not None
+    assert_layered_property_value(
+        before_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=1
+    )
+    assert_layered_property_value(
+        before_adding_result.data,
+        ["unfiltered", "meta", "totalCount"],
+        expected_value=1,
+    )
+
+    update_result = await test_schema.execute(
+        UPDATE_WIKIBASE_REUSE_MUTATION,
+        variable_values={"wikibaseId": 1, "reuse": False},
+        context_value=get_mock_context("test-auth-token"),
+    )
+    assert update_result.errors is None
+    assert update_result.data is not None
+    assert update_result.data["setReuseFlag"] is True
+
+    after_adding_result = await test_schema.execute(WIKIBASE_COUNT_QUERY)
+    assert after_adding_result.errors is None
+    assert after_adding_result.data is not None
+    assert_layered_property_value(
+        after_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=0
+    )
+    assert_layered_property_value(
+        after_adding_result.data, ["unfiltered", "meta", "totalCount"], expected_value=1
+    )

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -8,24 +8,27 @@ from tests.utils import assert_layered_property_value, get_mock_context
 
 WIKIBASE_COUNT_QUERY = """
 query PageWikibases {
-  filtered: wikibaseList(pageNumber: 1, pageSize: 1) {
+  filtered: wikibaseList(pageNumber: 1, pageSize: 100) {
     meta {
       totalCount
     }
     data {
-        id
+      id
     }
   }
-  unfiltered: wikibaseList(pageNumber: 1, pageSize: 1, wikibaseFilter: { ignoreReuse: true } ) {
+  unfiltered: wikibaseList(
+    pageNumber: 1
+    pageSize: 100
+    wikibaseFilter: { ignoreReuse: true }
+  ) {
     meta {
       totalCount
     }
     data {
-        id
+      id
     }
   }
-}
-"""
+}"""
 
 UPDATE_WIKIBASE_REUSE_MUTATION = """
 mutation MyMutation($wikibaseId: Int!, $reuse: Boolean!) {
@@ -57,15 +60,17 @@ async def test_set_wikibase_reuse_true():
     )
 
     before_adding_reuse_all_ids = {
-        w["id"] for w in before_adding_result.data["unfiltered"]["data"]
+        int(w["id"]) for w in before_adding_result.data["unfiltered"]["data"]
     }
+    assert len(before_adding_reuse_all_ids) > 0, f"{before_adding_result.data}"
     before_adding_reuse_true_ids = {
-        w["id"] for w in before_adding_result.data["filtered"]["data"]
+        int(w["id"]) for w in before_adding_result.data["filtered"]["data"]
     }
+    assert len(before_adding_reuse_true_ids) > 0, f"{before_adding_result.data}"
     before_adding_reuse_false_ids = (
         before_adding_reuse_all_ids - before_adding_reuse_true_ids
     )
-    assert len(before_adding_reuse_false_ids) == 1
+    assert len(before_adding_reuse_false_ids) > 0, f"{before_adding_result.data}"
 
     for wiki_id in before_adding_reuse_false_ids:
         update_result = await test_schema.execute(

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -33,7 +33,7 @@ mutation MyMutation($wikibaseId: Int!, $reuse: Boolean!) {
 }
 """
 
-
+@pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.mutation
 @pytest.mark.dependency(
@@ -69,7 +69,7 @@ async def test_set_wikibase_reuse_true():
     for wiki_id in before_adding_reuse_false_ids:
         update_result = await test_schema.execute(
             UPDATE_WIKIBASE_REUSE_MUTATION,
-            variable_values={"wikibaseId": wiki_id, "reuse": True},
+            variable_values={"wikibaseId": wiki_id, "reuse": "true"},
             context_value=get_mock_context("test-auth-token"),
         )
         assert update_result.errors is None

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -42,6 +42,7 @@ mutation MyMutation($wikibaseId: Int!, $reuse: Boolean!) {
 @pytest.mark.dependency(
     name="wikibase-set-reuse-false",
     depends=["transform-cloud-instance"],
+    scope="session",
 )
 async def test_set_wikibase_reuse_false():
     """Set Wikibase Reuse False"""

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -12,10 +12,16 @@ query PageWikibases {
     meta {
       totalCount
     }
+    data {
+        id
+    }
   }
   unfiltered: wikibaseList(pageNumber: 1, pageSize: 1, wikibaseFilter: { ignoreReuse:True } ) {
     meta {
       totalCount
+    }
+    data {
+        id
     }
   }
 }

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -41,7 +41,7 @@ mutation MyMutation($wikibaseId: Int!, $reuse: Boolean!) {
 @pytest.mark.mutation
 @pytest.mark.dependency(
     name="wikibase-set-reuse-true",
-    depends=["transform-cloud-instance"],
+    depends=["transform-cloud-instance", "wikibase-set-reuse-false"],
     scope="session",
 )
 async def test_set_wikibase_reuse_true():
@@ -53,7 +53,7 @@ async def test_set_wikibase_reuse_true():
     assert before_adding_result.errors is None
     assert before_adding_result.data is not None
     assert_layered_property_value(
-        before_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=2
+        before_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=1
     )
     assert_layered_property_value(
         before_adding_result.data,
@@ -70,7 +70,7 @@ async def test_set_wikibase_reuse_true():
     before_adding_reuse_false_ids = (
         before_adding_reuse_all_ids - before_adding_reuse_true_ids
     )
-    assert len(before_adding_reuse_false_ids) == 1, f"{before_adding_result.data}"
+    assert len(before_adding_reuse_false_ids) == 2, f"{before_adding_result.data}"
 
     for wiki_id in before_adding_reuse_false_ids:
         update_result = await test_schema.execute(
@@ -95,11 +95,71 @@ async def test_set_wikibase_reuse_true():
     )
 
 
-@pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.mutation
 @pytest.mark.dependency(
-    name="wikibase-set-reuse-false", depends=["add-wikibase"], scope="session"
+    name="cloud-wikibase-set-reuse-true",
+    depends=["mutate-cloud-instances"],
+    scope="session",
+)
+async def test_set_cloud_wikibase_reuse_true():
+    """Set Cloud Wikibases Reuse True"""
+
+    before_adding_result = await test_schema.execute(
+        WIKIBASE_FILTERED_AND_UNFILTERED_QUERY
+    )
+    assert before_adding_result.errors is None
+    assert before_adding_result.data is not None
+    assert_layered_property_value(
+        before_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=3
+    )
+    assert_layered_property_value(
+        before_adding_result.data,
+        ["unfiltered", "meta", "totalCount"],
+        expected_value=11,
+    )
+
+    before_adding_reuse_all_ids = {
+        int(w["id"]) for w in before_adding_result.data["unfiltered"]["data"]
+    }
+    before_adding_reuse_true_ids = {
+        int(w["id"]) for w in before_adding_result.data["filtered"]["data"]
+    }
+    before_adding_reuse_false_ids = (
+        before_adding_reuse_all_ids - before_adding_reuse_true_ids
+    )
+    assert len(before_adding_reuse_false_ids) == 8, f"{before_adding_result.data}"
+
+    for wiki_id in before_adding_reuse_false_ids:
+        update_result = await test_schema.execute(
+            UPDATE_WIKIBASE_REUSE_MUTATION,
+            variable_values={"wikibaseId": wiki_id, "reuse": True},
+            context_value=get_mock_context("test-auth-token"),
+        )
+        assert update_result.errors is None
+        assert update_result.data is not None
+        assert update_result.data["setReuseFlag"] is True
+
+    after_adding_result = await test_schema.execute(
+        WIKIBASE_FILTERED_AND_UNFILTERED_QUERY
+    )
+    assert after_adding_result.errors is None
+    assert after_adding_result.data is not None
+    assert_layered_property_value(
+        after_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=11
+    )
+    assert_layered_property_value(
+        after_adding_result.data,
+        ["unfiltered", "meta", "totalCount"],
+        expected_value=11,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.mutation
+@pytest.mark.dependency(
+    name="wikibase-set-reuse-false",
+    depends=["transform-cloud-instance"],
 )
 async def test_set_wikibase_reuse_false():
     """Set Wikibase Reuse False"""
@@ -110,17 +170,24 @@ async def test_set_wikibase_reuse_false():
     assert before_adding_result.errors is None
     assert before_adding_result.data is not None
     assert_layered_property_value(
-        before_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=1
+        before_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=2
     )
     assert_layered_property_value(
         before_adding_result.data,
         ["unfiltered", "meta", "totalCount"],
-        expected_value=1,
+        expected_value=3,
     )
+
+    before_adding_reuse_true_ids = {
+        int(w["id"]) for w in before_adding_result.data["filtered"]["data"]
+    }
 
     update_result = await test_schema.execute(
         UPDATE_WIKIBASE_REUSE_MUTATION,
-        variable_values={"wikibaseId": 1, "reuse": False},
+        variable_values={
+            "wikibaseId": before_adding_reuse_true_ids.pop(),
+            "reuse": True,
+        },
         context_value=get_mock_context("test-auth-token"),
     )
     assert update_result.errors is None
@@ -133,8 +200,8 @@ async def test_set_wikibase_reuse_false():
     assert after_adding_result.errors is None
     assert after_adding_result.data is not None
     assert_layered_property_value(
-        after_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=0
+        after_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=1
     )
     assert_layered_property_value(
-        after_adding_result.data, ["unfiltered", "meta", "totalCount"], expected_value=1
+        after_adding_result.data, ["unfiltered", "meta", "totalCount"], expected_value=3
     )

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -34,7 +34,6 @@ mutation MyMutation($wikibaseId: Int!, $reuse: Boolean!) {
 """
 
 
-@pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.mutation
 @pytest.mark.dependency(
@@ -70,7 +69,7 @@ async def test_set_wikibase_reuse_true():
     for wiki_id in before_adding_reuse_false_ids:
         update_result = await test_schema.execute(
             UPDATE_WIKIBASE_REUSE_MUTATION,
-            variable_values={"wikibaseId": wiki_id, "reuse": "true"},
+            variable_values={"wikibaseId": wiki_id, "reuse": True},
             context_value=get_mock_context("test-auth-token"),
         )
         assert update_result.errors is None

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -33,6 +33,7 @@ mutation MyMutation($wikibaseId: Int!, $reuse: Boolean!) {
 }
 """
 
+
 @pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.mutation

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -37,7 +37,9 @@ mutation MyMutation($wikibaseId: Int!, $reuse: Boolean!) {
 @pytest.mark.asyncio
 @pytest.mark.mutation
 @pytest.mark.dependency(
-    name="wikibase-set-reuse-true", depends=["add-wikibase"], scope="session"
+    name="wikibase-set-reuse-true",
+    depends=["add-wikibase", "transform-cloud-instances"],
+    scope="session",
 )
 async def test_set_wikibase_reuse_true():
     """Set Wikibase Reuse True"""
@@ -51,29 +53,41 @@ async def test_set_wikibase_reuse_true():
     assert_layered_property_value(
         before_adding_result.data,
         ["unfiltered", "meta", "totalCount"],
-        expected_value=1,
+        expected_value=2,
     )
 
-    update_result = await test_schema.execute(
-        UPDATE_WIKIBASE_REUSE_MUTATION,
-        variable_values={"wikibaseId": 1, "reuse": True},
-        context_value=get_mock_context("test-auth-token"),
+    before_adding_reuse_all_ids = {
+        w["id"] for w in before_adding_result.data["unfiltered"]["data"]
+    }
+    before_adding_reuse_true_ids = {
+        w["id"] for w in before_adding_result.data["filtered"]["data"]
+    }
+    before_adding_reuse_false_ids = (
+        before_adding_reuse_all_ids - before_adding_reuse_true_ids
     )
-    assert update_result.errors is None
-    assert update_result.data is not None
-    assert update_result.data["setReuseFlag"] is True
+
+    for wiki_id in before_adding_reuse_false_ids:
+        update_result = await test_schema.execute(
+            UPDATE_WIKIBASE_REUSE_MUTATION,
+            variable_values={"wikibaseId": wiki_id, "reuse": True},
+            context_value=get_mock_context("test-auth-token"),
+        )
+        assert update_result.errors is None
+        assert update_result.data is not None
+        assert update_result.data["setReuseFlag"] is True
 
     after_adding_result = await test_schema.execute(WIKIBASE_COUNT_QUERY)
     assert after_adding_result.errors is None
     assert after_adding_result.data is not None
     assert_layered_property_value(
-        after_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=1
+        after_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=2
     )
     assert_layered_property_value(
-        after_adding_result.data, ["unfiltered", "meta", "totalCount"], expected_value=1
+        after_adding_result.data, ["unfiltered", "meta", "totalCount"], expected_value=2
     )
 
 
+@pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.mutation
 @pytest.mark.dependency(

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -6,7 +6,7 @@ import pytest
 from tests.test_schema import test_schema
 from tests.utils import assert_layered_property_value, get_mock_context
 
-WIKIBASE_COUNT_QUERY = """
+WIKIBASE_FILTERED_AND_UNFILTERED_QUERY = """
 query PageWikibases {
   filtered: wikibaseList(pageNumber: 1, pageSize: 100) {
     meta {
@@ -47,7 +47,9 @@ mutation MyMutation($wikibaseId: Int!, $reuse: Boolean!) {
 async def test_set_wikibase_reuse_true():
     """Set Wikibase Reuse True"""
 
-    before_adding_result = await test_schema.execute(WIKIBASE_COUNT_QUERY)
+    before_adding_result = await test_schema.execute(
+        WIKIBASE_FILTERED_AND_UNFILTERED_QUERY
+    )
     assert before_adding_result.errors is None
     assert before_adding_result.data is not None
     assert_layered_property_value(
@@ -62,15 +64,13 @@ async def test_set_wikibase_reuse_true():
     before_adding_reuse_all_ids = {
         int(w["id"]) for w in before_adding_result.data["unfiltered"]["data"]
     }
-    assert len(before_adding_reuse_all_ids) > 0, f"{before_adding_result.data}"
     before_adding_reuse_true_ids = {
         int(w["id"]) for w in before_adding_result.data["filtered"]["data"]
     }
-    assert len(before_adding_reuse_true_ids) > 0, f"{before_adding_result.data}"
     before_adding_reuse_false_ids = (
         before_adding_reuse_all_ids - before_adding_reuse_true_ids
     )
-    assert len(before_adding_reuse_false_ids) > 0, f"{before_adding_result.data}"
+    assert len(before_adding_reuse_false_ids) == 1, f"{before_adding_result.data}"
 
     for wiki_id in before_adding_reuse_false_ids:
         update_result = await test_schema.execute(
@@ -82,7 +82,9 @@ async def test_set_wikibase_reuse_true():
         assert update_result.data is not None
         assert update_result.data["setReuseFlag"] is True
 
-    after_adding_result = await test_schema.execute(WIKIBASE_COUNT_QUERY)
+    after_adding_result = await test_schema.execute(
+        WIKIBASE_FILTERED_AND_UNFILTERED_QUERY
+    )
     assert after_adding_result.errors is None
     assert after_adding_result.data is not None
     assert_layered_property_value(
@@ -102,7 +104,9 @@ async def test_set_wikibase_reuse_true():
 async def test_set_wikibase_reuse_false():
     """Set Wikibase Reuse False"""
 
-    before_adding_result = await test_schema.execute(WIKIBASE_COUNT_QUERY)
+    before_adding_result = await test_schema.execute(
+        WIKIBASE_FILTERED_AND_UNFILTERED_QUERY
+    )
     assert before_adding_result.errors is None
     assert before_adding_result.data is not None
     assert_layered_property_value(
@@ -123,7 +127,9 @@ async def test_set_wikibase_reuse_false():
     assert update_result.data is not None
     assert update_result.data["setReuseFlag"] is True
 
-    after_adding_result = await test_schema.execute(WIKIBASE_COUNT_QUERY)
+    after_adding_result = await test_schema.execute(
+        WIKIBASE_FILTERED_AND_UNFILTERED_QUERY
+    )
     assert after_adding_result.errors is None
     assert after_adding_result.data is not None
     assert_layered_property_value(

--- a/backend/tests/test_mutation/test_update_wikibase_reuse.py
+++ b/backend/tests/test_mutation/test_update_wikibase_reuse.py
@@ -48,12 +48,12 @@ async def test_set_wikibase_reuse_true():
     assert before_adding_result.errors is None
     assert before_adding_result.data is not None
     assert_layered_property_value(
-        before_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=1
+        before_adding_result.data, ["filtered", "meta", "totalCount"], expected_value=2
     )
     assert_layered_property_value(
         before_adding_result.data,
         ["unfiltered", "meta", "totalCount"],
-        expected_value=2,
+        expected_value=3,
     )
 
     before_adding_reuse_all_ids = {

--- a/backend/tests/test_mutation/test_update_wikibase_type.py
+++ b/backend/tests/test_mutation/test_update_wikibase_type.py
@@ -142,7 +142,7 @@ async def test_update_wikibase_type_to_suite(get_test_wikibase_id):
 @pytest.mark.mutation
 @pytest.mark.dependency(
     name="update-wikibase-type-test",
-    depends=["mutate-cloud-instances"],
+    depends=["mutate-cloud-instances", "cloud-wikibase-set-reuse-true"],
     scope="session",
 )
 async def test_update_wikibase_type_to_test(get_test_wikibase_id):
@@ -182,7 +182,9 @@ async def test_update_wikibase_type_to_test(get_test_wikibase_id):
 
 @pytest.mark.asyncio
 @pytest.mark.mutation
-@pytest.mark.dependency(depends=["mutate-cloud-instances"], scope="session")
+@pytest.mark.dependency(
+    depends=["mutate-cloud-instances", "cloud-wikibase-set-reuse-true"], scope="session"
+)
 async def test_update_wikibase_type_to_same(get_test_wikibase_id):
     """Test Update to Current Value"""
 

--- a/backend/tests/test_mutation/test_update_wikibase_url.py
+++ b/backend/tests/test_mutation/test_update_wikibase_url.py
@@ -188,7 +188,7 @@ async def test_remove_wikibase_sparql_frontend_url():
 @pytest.mark.mutation
 @pytest.mark.dependency(
     name="remove-wikibase-article-path",
-    depends=["mutate-cloud-instances"],
+    depends=["mutate-cloud-instances", "cloud-wikibase-set-reuse-true"],
     scope="session",
 )
 async def test_remove_wikibase_article_path(get_wikibase_id_by_base_url):

--- a/backend/tests/test_query/aggregation/software_version/test_aggregate_extensions_query.py
+++ b/backend/tests/test_query/aggregation/software_version/test_aggregate_extensions_query.py
@@ -38,12 +38,7 @@ async def test_aggregate_extensions_query_page_one():
     """Test Aggregated Extensions Query - 1-5"""
 
     result = await test_schema.execute(
-        AGGREGATE_EXTENSIONS_QUERY,
-        variable_values={
-            "pageNumber": 1,
-            "pageSize": 5,
-            "wikibaseFilter": {"ignoreReuse": True},
-        },
+        AGGREGATE_EXTENSIONS_QUERY, variable_values={"pageNumber": 1, "pageSize": 5}
     )
 
     assert result.errors is None
@@ -113,12 +108,7 @@ async def test_aggregate_extensions_query_page_two():
     """Test Aggregated Extensions Query - 6-10"""
 
     result = await test_schema.execute(
-        AGGREGATE_EXTENSIONS_QUERY,
-        variable_values={
-            "pageNumber": 2,
-            "pageSize": 5,
-            "wikibaseFilter": {"ignoreReuse": True},
-        },
+        AGGREGATE_EXTENSIONS_QUERY, variable_values={"pageNumber": 2, "pageSize": 5}
     )
 
     assert result.errors is None
@@ -182,12 +172,7 @@ async def test_aggregate_extensions_query_page_three():
     """Test Aggregated Extensions Query - 11-12"""
 
     result = await test_schema.execute(
-        AGGREGATE_EXTENSIONS_QUERY,
-        variable_values={
-            "pageNumber": 3,
-            "pageSize": 5,
-            "wikibaseFilter": {"ignoreReuse": True},
-        },
+        AGGREGATE_EXTENSIONS_QUERY, variable_values={"pageNumber": 3, "pageSize": 5}
     )
 
     assert result.errors is None
@@ -262,10 +247,7 @@ async def test_aggregate_extensions_query_filtered(exclude: list, expected_count
         variable_values={
             "pageNumber": 1,
             "pageSize": 1,
-            "wikibaseFilter": {
-                "wikibaseType": {"exclude": exclude},
-                "ignoreReuse": True,
-            },
+            "wikibaseFilter": {"wikibaseType": {"exclude": exclude}},
         },
     )
 

--- a/backend/tests/test_query/aggregation/software_version/test_aggregate_extensions_query.py
+++ b/backend/tests/test_query/aggregation/software_version/test_aggregate_extensions_query.py
@@ -38,7 +38,12 @@ async def test_aggregate_extensions_query_page_one():
     """Test Aggregated Extensions Query - 1-5"""
 
     result = await test_schema.execute(
-        AGGREGATE_EXTENSIONS_QUERY, variable_values={"pageNumber": 1, "pageSize": 5}
+        AGGREGATE_EXTENSIONS_QUERY,
+        variable_values={
+            "pageNumber": 1,
+            "pageSize": 5,
+            "wikibaseFilter": {"ignoreReuse": True},
+        },
     )
 
     assert result.errors is None
@@ -108,7 +113,12 @@ async def test_aggregate_extensions_query_page_two():
     """Test Aggregated Extensions Query - 6-10"""
 
     result = await test_schema.execute(
-        AGGREGATE_EXTENSIONS_QUERY, variable_values={"pageNumber": 2, "pageSize": 5}
+        AGGREGATE_EXTENSIONS_QUERY,
+        variable_values={
+            "pageNumber": 2,
+            "pageSize": 5,
+            "wikibaseFilter": {"ignoreReuse": True},
+        },
     )
 
     assert result.errors is None
@@ -172,7 +182,12 @@ async def test_aggregate_extensions_query_page_three():
     """Test Aggregated Extensions Query - 11-12"""
 
     result = await test_schema.execute(
-        AGGREGATE_EXTENSIONS_QUERY, variable_values={"pageNumber": 3, "pageSize": 5}
+        AGGREGATE_EXTENSIONS_QUERY,
+        variable_values={
+            "pageNumber": 3,
+            "pageSize": 5,
+            "wikibaseFilter": {"ignoreReuse": True},
+        },
     )
 
     assert result.errors is None
@@ -247,7 +262,10 @@ async def test_aggregate_extensions_query_filtered(exclude: list, expected_count
         variable_values={
             "pageNumber": 1,
             "pageSize": 1,
-            "wikibaseFilter": {"wikibaseType": {"exclude": exclude}},
+            "wikibaseFilter": {
+                "wikibaseType": {"exclude": exclude},
+                "ignoreReuse": True,
+            },
         },
     )
 

--- a/backend/tests/test_query/aggregation/software_version/test_aggregate_software_query.py
+++ b/backend/tests/test_query/aggregation/software_version/test_aggregate_software_query.py
@@ -31,9 +31,7 @@ query MyQuery($pageNumber: Int!, $pageSize: Int!, $wikibaseFilter: WikibaseFilte
 
 @pytest.mark.asyncio
 @pytest.mark.agg
-@pytest.mark.dependency(
-    depends=["software-version-success", "wikibase-set-reuse-true"], scope="session"
-)
+@pytest.mark.dependency(depends=["software-version-success"], scope="session")
 @pytest.mark.query
 @pytest.mark.version
 async def test_aggregate_software_query():

--- a/backend/tests/test_query/aggregation/software_version/test_aggregate_software_query.py
+++ b/backend/tests/test_query/aggregation/software_version/test_aggregate_software_query.py
@@ -31,7 +31,9 @@ query MyQuery($pageNumber: Int!, $pageSize: Int!, $wikibaseFilter: WikibaseFilte
 
 @pytest.mark.asyncio
 @pytest.mark.agg
-@pytest.mark.dependency(depends=["software-version-success"], scope="session")
+@pytest.mark.dependency(
+    depends=["software-version-success", "wikibase-set-reuse-true"], scope="session"
+)
 @pytest.mark.query
 @pytest.mark.version
 async def test_aggregate_software_query():

--- a/backend/tests/test_query/test_wikibase_list_sort_category_query.py
+++ b/backend/tests/test_query/test_wikibase_list_sort_category_query.py
@@ -9,7 +9,9 @@ from tests.utils import assert_layered_property_value, assert_page_meta
 @pytest.mark.asyncio
 @pytest.mark.query
 @pytest.mark.dependency(
-    name="sort-cat-asc", depends=["mutate-cloud-instances"], scope="session"
+    name="sort-cat-asc",
+    depends=["mutate-cloud-instances", "cloud-wikibase-set-reuse-true"],
+    scope="session",
 )
 async def test_wikibase_list_query_sort_category_asc():
     """Test Sort Category Ascending"""
@@ -61,7 +63,9 @@ async def test_wikibase_list_query_sort_category_asc():
 @pytest.mark.asyncio
 @pytest.mark.query
 @pytest.mark.dependency(
-    name="sort-cat-desc", depends=["mutate-cloud-instances"], scope="session"
+    name="sort-cat-desc",
+    depends=["mutate-cloud-instances", "cloud-wikibase-set-reuse-true"],
+    scope="session",
 )
 async def test_wikibase_list_query_sort_category_desc():
     """Test Sort Category Descending"""

--- a/backend/tests/test_query/test_wikibase_list_sort_edits_query.py
+++ b/backend/tests/test_query/test_wikibase_list_sort_edits_query.py
@@ -9,7 +9,9 @@ from tests.utils import assert_layered_property_value, assert_page_meta
 @pytest.mark.asyncio
 @pytest.mark.query
 @pytest.mark.dependency(
-    name="sort-edits-asc", depends=["mutate-cloud-instances"], scope="session"
+    name="sort-edits-asc",
+    depends=["mutate-cloud-instances", "cloud-wikibase-set-reuse-true"],
+    scope="session",
 )
 async def test_wikibase_list_query_sort_edits_asc():
     """Test Sort Edits Ascending"""
@@ -63,7 +65,9 @@ async def test_wikibase_list_query_sort_edits_asc():
 @pytest.mark.asyncio
 @pytest.mark.query
 @pytest.mark.dependency(
-    name="sort-edits-desc", depends=["mutate-cloud-instances"], scope="session"
+    name="sort-edits-desc",
+    depends=["mutate-cloud-instances", "cloud-wikibase-set-reuse-true"],
+    scope="session",
 )
 async def test_wikibase_list_query_sort_edits_desc():
     """Test Sort Edits Descending"""

--- a/backend/tests/test_query/test_wikibase_list_sort_title_query.py
+++ b/backend/tests/test_query/test_wikibase_list_sort_title_query.py
@@ -9,7 +9,9 @@ from tests.utils import assert_layered_property_value, assert_page_meta
 @pytest.mark.asyncio
 @pytest.mark.query
 @pytest.mark.dependency(
-    name="sort-title-asc", depends=["mutate-cloud-instances"], scope="session"
+    name="sort-title-asc",
+    depends=["mutate-cloud-instances", "cloud-wikibase-set-reuse-true"],
+    scope="session",
 )
 async def test_wikibase_list_query_sort_title_asc():
     """Test Sort Title Ascending"""
@@ -84,7 +86,9 @@ async def test_wikibase_list_query_sort_title_asc():
 @pytest.mark.asyncio
 @pytest.mark.query
 @pytest.mark.dependency(
-    name="sort-title-desc", depends=["mutate-cloud-instances"], scope="session"
+    name="sort-title-desc",
+    depends=["mutate-cloud-instances", "cloud-wikibase-set-reuse-true"],
+    scope="session",
 )
 async def test_wikibase_list_query_sort_title_desc():
     """Test Sort Title Descending"""

--- a/backend/tests/test_query/test_wikibase_list_sort_triples_query.py
+++ b/backend/tests/test_query/test_wikibase_list_sort_triples_query.py
@@ -9,7 +9,9 @@ from tests.utils import assert_layered_property_value, assert_page_meta
 @pytest.mark.asyncio
 @pytest.mark.query
 @pytest.mark.dependency(
-    name="sort-trip-asc", depends=["mutate-cloud-instances"], scope="session"
+    name="sort-trip-asc",
+    depends=["mutate-cloud-instances", "cloud-wikibase-set-reuse-true"],
+    scope="session",
 )
 async def test_wikibase_list_query_sort_triples_asc():
     """Test Sort Triples Ascending"""
@@ -51,7 +53,9 @@ async def test_wikibase_list_query_sort_triples_asc():
 @pytest.mark.asyncio
 @pytest.mark.query
 @pytest.mark.dependency(
-    name="sort-trip-desc", depends=["mutate-cloud-instances"], scope="session"
+    name="sort-trip-desc",
+    depends=["mutate-cloud-instances", "cloud-wikibase-set-reuse-true"],
+    scope="session",
 )
 async def test_wikibase_list_query_sort_triples_desc():
     """Test Sort Triples Descending"""

--- a/backend/tests/test_query/test_wikibase_list_sort_type_query.py
+++ b/backend/tests/test_query/test_wikibase_list_sort_type_query.py
@@ -8,7 +8,9 @@ from tests.utils import assert_page_meta
 
 @pytest.mark.asyncio
 @pytest.mark.dependency(
-    name="sort-type-asc", depends=["mutate-cloud-instances"], scope="session"
+    name="sort-type-asc",
+    depends=["mutate-cloud-instances", "cloud-wikibase-set-reuse-true"],
+    scope="session",
 )
 @pytest.mark.query
 async def test_wikibase_list_query_sort_type_asc():
@@ -47,7 +49,9 @@ async def test_wikibase_list_query_sort_type_asc():
 
 @pytest.mark.asyncio
 @pytest.mark.dependency(
-    name="sort-type-desc", depends=["mutate-cloud-instances"], scope="session"
+    name="sort-type-desc",
+    depends=["mutate-cloud-instances", "cloud-wikibase-set-reuse-true"],
+    scope="session",
 )
 @pytest.mark.query
 async def test_wikibase_list_query_sort_type_desc():

--- a/backend/tests/test_upsert_cloud_instances/constant.py
+++ b/backend/tests/test_upsert_cloud_instances/constant.py
@@ -4,7 +4,11 @@ DATA_DIRECTORY = "tests/test_upsert_cloud_instances/data"
 
 WIKIBASE_LIST_QUERY = """
 query MyQuery {
-  wikibaseList(pageNumber: 1, pageSize: 10000) {
+  wikibaseList(
+    pageNumber: 1
+    pageSize: 10000
+    wikibaseFilter: { ignoreReuse: true }
+  ) {
     data {
       id
       wikibaseType

--- a/backend/tests/test_upsert_cloud_instances/test_mutate_cloud_instances.py
+++ b/backend/tests/test_upsert_cloud_instances/test_mutate_cloud_instances.py
@@ -23,9 +23,9 @@ mutation MyMutation {
     name="mutate-cloud-instances", depends=["query-cloud-instances"], scope="session"
 )
 @pytest.mark.asyncio
-async def test_query_cloud_instance(mocker):
+async def test_add_cloud_instance(mocker):
     """
-    test whether querying the wikibase list via graphql returns a cloud instance
+    test adding a list of cloud instances
     """
 
     with open(

--- a/backend/tests/test_upsert_cloud_instances/test_query_cloud_instances.py
+++ b/backend/tests/test_upsert_cloud_instances/test_query_cloud_instances.py
@@ -7,7 +7,9 @@ from tests.test_upsert_cloud_instances.constant import WIKIBASE_LIST_QUERY
 
 
 @pytest.mark.dependency(
-    name="query-cloud-instances", depends=["transform-cloud-instances"], scope="session"
+    name="query-cloud-instances",
+    depends=["transform-cloud-instance", "wikibase-set-reuse-true"],
+    scope="session",
 )
 @pytest.mark.asyncio
 async def test_query_cloud_instance():

--- a/backend/tests/test_upsert_cloud_instances/test_upsert_cloud_instances.py
+++ b/backend/tests/test_upsert_cloud_instances/test_upsert_cloud_instances.py
@@ -126,9 +126,7 @@ async def test_update_cloud_instances(mocker):
 
 
 @pytest.mark.dependency(
-    name="transform-cloud-instance",
-    depends=["update-cloud-instance"],
-    scope="session",
+    name="transform-cloud-instance", depends=["update-cloud-instance"], scope="session"
 )
 @pytest.mark.asyncio
 async def test_transform_to_cloud_instance(mocker):

--- a/backend/tests/test_upsert_cloud_instances/test_upsert_cloud_instances.py
+++ b/backend/tests/test_upsert_cloud_instances/test_upsert_cloud_instances.py
@@ -12,7 +12,7 @@ from tests.test_upsert_cloud_instances.constant import DATA_DIRECTORY
 from tests.utils import MockResponse
 
 
-@pytest.mark.dependency(name="insert-cloud-instances", scope="session")
+@pytest.mark.dependency(name="insert-cloud-instance", scope="session")
 @pytest.mark.asyncio
 async def test_insert_cloud_instances(mocker):
     """
@@ -67,10 +67,11 @@ async def test_insert_cloud_instances(mocker):
                 found.sparql_endpoint_url.url
                 == "https://tcdict.wikibase.cloud/query/sparql"
             )
+            assert found.reuse is False
 
 
 @pytest.mark.dependency(
-    name="update-cloud-instances", depends=["insert-cloud-instances"], scope="session"
+    name="update-cloud-instance", depends=["insert-cloud-instance"], scope="session"
 )
 @pytest.mark.asyncio
 async def test_update_cloud_instances(mocker):
@@ -125,8 +126,8 @@ async def test_update_cloud_instances(mocker):
 
 
 @pytest.mark.dependency(
-    name="transform-cloud-instances",
-    depends=["update-cloud-instances"],
+    name="transform-cloud-instance",
+    depends=["update-cloud-instance"],
     scope="session",
 )
 @pytest.mark.asyncio

--- a/frontend/src/graphql/graphql.ts
+++ b/frontend/src/graphql/graphql.ts
@@ -64,6 +64,8 @@ export type Mutation = {
 	removeWikibaseUrl: Scalars['Boolean']['output']
 	/** Set Extension Bundled with WBS */
 	setExtensionWbsBundled: Scalars['Boolean']['output']
+	/** Set Reuse Flag for Wikibase */
+	setReuseFlag: Scalars['Boolean']['output']
 	/** Fetch Connectivity Data from All Wikibase Instances */
 	updateAllConnectivityData: BulkTaskResult
 	/** Fetch External Identifier Data from All Wikibase Instances */
@@ -162,6 +164,11 @@ export type MutationRemoveWikibaseUrlArgs = {
 export type MutationSetExtensionWbsBundledArgs = {
 	bundled?: Scalars['Boolean']['input']
 	extensionId: Scalars['Int']['input']
+}
+
+export type MutationSetReuseFlagArgs = {
+	reuse: Scalars['Boolean']['input']
+	wikibaseId: Scalars['Int']['input']
 }
 
 export type MutationUpdateAllLogDataArgs = {
@@ -464,6 +471,7 @@ export type WikibaseExternalIdentifierObservationWikibaseObservationSet = {
 }
 
 export type WikibaseFilterInput = {
+	ignoreReuse?: InputMaybe<Scalars['Boolean']['input']>
 	wikibaseType?: InputMaybe<WikibaseTypeInput>
 }
 
@@ -473,10 +481,11 @@ export type WikibaseInput = {
 	description?: InputMaybe<Scalars['String']['input']>
 	organization?: InputMaybe<Scalars['String']['input']>
 	region?: InputMaybe<Scalars['String']['input']>
+	reuse?: InputMaybe<Scalars['Boolean']['input']>
 	test?: InputMaybe<Scalars['Boolean']['input']>
 	urls: WikibaseUrlSetInput
 	wikibaseName: Scalars['String']['input']
-	wikibaseType: string
+	wikibaseType?: InputMaybe<WikibaseType>
 }
 
 export type WikibaseItemDate = {

--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -61,6 +61,8 @@ export type Mutation = {
 	removeWikibaseUrl: Scalars['Boolean']['output']
 	/** Set Extension Bundled with WBS */
 	setExtensionWbsBundled: Scalars['Boolean']['output']
+	/** Set Reuse Flag for Wikibase */
+	setReuseFlag: Scalars['Boolean']['output']
 	/** Fetch Connectivity Data from All Wikibase Instances */
 	updateAllConnectivityData: BulkTaskResult
 	/** Fetch External Identifier Data from All Wikibase Instances */
@@ -159,6 +161,11 @@ export type MutationRemoveWikibaseUrlArgs = {
 export type MutationSetExtensionWbsBundledArgs = {
 	bundled?: Scalars['Boolean']['input']
 	extensionId: Scalars['Int']['input']
+}
+
+export type MutationSetReuseFlagArgs = {
+	reuse: Scalars['Boolean']['input']
+	wikibaseId: Scalars['Int']['input']
 }
 
 export type MutationUpdateAllLogDataArgs = {
@@ -461,6 +468,7 @@ export type WikibaseExternalIdentifierObservationWikibaseObservationSet = {
 }
 
 export type WikibaseFilterInput = {
+	ignoreReuse?: InputMaybe<Scalars['Boolean']['input']>
 	wikibaseType?: InputMaybe<WikibaseTypeInput>
 }
 
@@ -470,10 +478,11 @@ export type WikibaseInput = {
 	description?: InputMaybe<Scalars['String']['input']>
 	organization?: InputMaybe<Scalars['String']['input']>
 	region?: InputMaybe<Scalars['String']['input']>
+	reuse?: InputMaybe<Scalars['Boolean']['input']>
 	test?: InputMaybe<Scalars['Boolean']['input']>
 	urls: WikibaseUrlSetInput
 	wikibaseName: Scalars['String']['input']
-	wikibaseType: string
+	wikibaseType?: InputMaybe<WikibaseType>
 }
 
 export type WikibaseItemDate = {


### PR DESCRIPTION
Add a reuse flag
By default, exclude all where reuse is False or Null; the list filter now includes an optional ignoreReuse parameter
Add a setReuseFlag(wikibaseId, reuse) mutation
