### PR TITLE
Implement Matomo in Frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -33,6 +33,27 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta name="robots" content="noindex, nofollow" />
 		<title>Wikibase Ecosystem</title>
+
+		<!-- Matomo -->
+		<script>
+			var _paq = (window._paq = window._paq || [])
+			/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+			_paq.push(['setDocumentTitle', document.domain + '/' + document.title])
+			_paq.push(['setCookieDomain', '.wikiba.se'])
+			_paq.push(['trackPageView'])
+			_paq.push(['enableLinkTracking'])
+			;(function () {
+				var u = '//stats.wikimedia.de/'
+				_paq.push(['setTrackerUrl', u + 'matomo.php'])
+				_paq.push(['setSiteId', '12'])
+				var d = document,
+					g = d.createElement('script'),
+					s = d.getElementsByTagName('script')[0]
+				g.async = true
+				g.src = u + 'matomo.js'
+				s.parentNode.insertBefore(g, s)
+			})()
+		</script>
 	</head>
 	<body>
 		<div id="app"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
 				"pinia": "^3.0.3",
 				"serve": "^14.2.5",
 				"vue": "^3.5.22",
+				"vue-matomo": "^4.2.0",
 				"vuetify": "^3.10.5"
 			},
 			"devDependencies": {
@@ -12587,6 +12588,16 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/vue-matomo": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/vue-matomo/-/vue-matomo-4.2.0.tgz",
+			"integrity": "sha512-m5hCw7LH3wPDcERaF4sp/ojR9sEx7Rl8TpOyH/4jjQxMF2DuY/q5pO+i9o5Dx+BXLSa9+IQ0qhAbWYRyESQXmA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
 		"node_modules/vue-tsc": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.1.1.tgz",
@@ -12879,7 +12890,7 @@
 			"version": "8.18.3",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
 			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
 		"pinia": "^3.0.3",
 		"serve": "^14.2.5",
 		"vue": "^3.5.22",
+		"vue-matomo": "^4.2.0",
 		"vuetify": "^3.10.5"
 	},
 	"devDependencies": {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -6,15 +6,11 @@ import App from './App.vue'
 
 const app = createApp(App)
 
-createApp(App)
-	.use(VueMatomo, {
-		host: 'stats.wikimedia.de',
-		siteId: 12
-	})
-	.mount('#app')
-
 app.use(vuetify)
-
 app.use(createPinia())
+app.use(VueMatomo, {
+	host: 'https://stats.wikimedia.de',
+	siteId: 12
+})
 
 app.mount('#app')

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,9 +1,17 @@
 import vuetify from '@/plugin/vuetify'
 import { createPinia } from 'pinia'
 import { createApp } from 'vue'
+import VueMatomo from 'vue-matomo'
 import App from './App.vue'
 
 const app = createApp(App)
+
+createApp(App)
+	.use(VueMatomo, {
+		host: 'stats.wikimedia.de',
+		siteId: 12
+	})
+	.mount('#app')
 
 app.use(vuetify)
 

--- a/frontend/src/vue-matomo.d.ts
+++ b/frontend/src/vue-matomo.d.ts
@@ -1,0 +1,1 @@
+declare module 'vue-matomo'


### PR DESCRIPTION
This PR adds Matomo to the frontend to enable tracking click rates to measure usage with a cookie-less tracking method.