### PR TITLE
Fix action api URL case where scriptPath is empty

### DIFF
--- a/frontend/src/component/wikibase-table/wikibase-detail-card/WikibaseAccess.vue
+++ b/frontend/src/component/wikibase-table/wikibase-detail-card/WikibaseAccess.vue
@@ -8,13 +8,13 @@ const { wikibase } = defineProps<{ wikibase: SingleWikibaseFragment }>()
 const actionApiUrl = computed(() => {
 	const { baseUrl, scriptPath } = wikibase.urls
 
-	if (scriptPath === null) {
+	if (scriptPath === null || scriptPath === undefined) {
 		return null
 	}
 
 	const base = baseUrl.replace(/\/+$/, '')
 	// remove extra leading and trailing slashes
-	const s = scriptPath ? `/${scriptPath.replace(/^\/|\/$/g, '')}/` : '/'
+	const s = scriptPath.trim() ? `/${scriptPath.replace(/^\/|\/$/g, '')}/` : '/'
 	return `${base}${s}api.php`
 })
 </script>

--- a/frontend/src/component/wikibase-table/wikibase-detail-card/WikibaseAccess.vue
+++ b/frontend/src/component/wikibase-table/wikibase-detail-card/WikibaseAccess.vue
@@ -8,13 +8,14 @@ const { wikibase } = defineProps<{ wikibase: SingleWikibaseFragment }>()
 const actionApiUrl = computed(() => {
 	const { baseUrl, scriptPath } = wikibase.urls
 
-	if (!scriptPath) {
+	if (scriptPath === null) {
 		return null
 	}
 
 	const base = baseUrl.replace(/\/+$/, '')
-	const s = scriptPath.replace(/^\/|\/$/g, '') // remove leading and trailing slashes
-	return `${base}/${s}/api.php`
+	// remove extra leading and trailing slashes
+	const s = scriptPath ? `/${scriptPath.replace(/^\/|\/$/g, '')}/` : '/'
+	return `${base}${s}api.php`
 })
 </script>
 

--- a/frontend/src/component/wikibase-table/wikibase-detail-card/WikibaseAccess.vue
+++ b/frontend/src/component/wikibase-table/wikibase-detail-card/WikibaseAccess.vue
@@ -2,20 +2,13 @@
 import type { SingleWikibaseFragment } from '@/graphql/types'
 import { computed } from 'vue'
 import { mdiLink, mdiMagnify, mdiApi } from '@mdi/js'
+import getActionApiUrl from '@/util/getActionApiUrl'
 
 const { wikibase } = defineProps<{ wikibase: SingleWikibaseFragment }>()
 
 const actionApiUrl = computed(() => {
 	const { baseUrl, scriptPath } = wikibase.urls
-
-	if (scriptPath === null || scriptPath === undefined) {
-		return null
-	}
-
-	const base = baseUrl.replace(/\/+$/, '')
-	// remove extra leading and trailing slashes
-	const s = scriptPath.trim() ? `/${scriptPath.replace(/^\/|\/$/g, '')}/` : '/'
-	return `${base}${s}api.php`
+	return getActionApiUrl(baseUrl, scriptPath)
 })
 </script>
 

--- a/frontend/src/util/__tests__/getActionApiUrl.spec.ts
+++ b/frontend/src/util/__tests__/getActionApiUrl.spec.ts
@@ -1,0 +1,28 @@
+// src/utils/wikibaseUrls.test.ts
+import { describe, it, expect } from 'vitest'
+import getActionApiUrl from '@/util/getActionApiUrl'
+
+describe('getActionApiUrl', () => {
+	it('returns null if scriptPath is null', () => {
+		expect(getActionApiUrl('https://example.com', null)).toBeNull()
+	})
+
+	it('returns null if scriptPath is undefined', () => {
+		expect(getActionApiUrl('https://example.com', undefined)).toBeNull()
+	})
+
+	it('handles empty scriptPaths', () => {
+		expect(getActionApiUrl('https://example.com', '')).toBe('https://example.com/api.php')
+		expect(getActionApiUrl('https://example.com', '/')).toBe('https://example.com/api.php')
+	})
+
+	it('removes extra trailing and leading slashes in scriptPath', () => {
+		const scriptPaths = ['script', '/script', 'script/', '/script/']
+
+		for (const scriptPath of scriptPaths) {
+			expect(getActionApiUrl('https://example.com', scriptPath)).toBe(
+				`https://example.com/script/api.php`
+			)
+		}
+	})
+})

--- a/frontend/src/util/getActionApiUrl.ts
+++ b/frontend/src/util/getActionApiUrl.ts
@@ -1,0 +1,13 @@
+function getActionApiUrl(baseUrl: string, scriptPath: string | null | undefined): string | null {
+	if (scriptPath === null || scriptPath === undefined) {
+		return null
+	}
+
+	const base = baseUrl.replace(/\/+$/, '')
+	// remove extra leading and trailing slashes
+	const stripped = scriptPath.trim().replace(/^\/|\/$/g, '')
+	const s = stripped ? `/${stripped}/` : '/'
+	return `${base}${s}api.php`
+}
+
+export default getActionApiUrl


### PR DESCRIPTION
This change updates the action API generation logic to allow empty strings as valid `scriptPath` values. Null and undefined scriptPaths will still return null