### PR TITLE
Move HTML title to top of head

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,6 +2,7 @@
 <html lang="">
 	<head>
 		<meta charset="UTF-8" />
+		<title>Wikibase Ecosystem</title>
 		<link
 			rel="icon"
 			href="https://wikiba.se/wp-content/uploads/sites/7/2024/01/cropped-Wikibase-Favicon-32x32.png"
@@ -32,8 +33,6 @@
 		/>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta name="robots" content="noindex, nofollow" />
-		<title>Wikibase Ecosystem</title>
-
 		<!-- Matomo -->
 		<script>
 			var _paq = (window._paq = window._paq || [])


### PR DESCRIPTION
The HTML title is moved to the top of the head to make it clearer when reading the logs in Matomo