### PR TITLE
fix: T426940 - Nonarchived Software Tests

### DIFF
--- a/backend/data/gx/checkpoints/wikibase_software_checkpoint.json
+++ b/backend/data/gx/checkpoints/wikibase_software_checkpoint.json
@@ -25,6 +25,10 @@
 		{
 			"id": "8768e1d1-11d5-44a6-8f5d-0a03d1d535d4",
 			"name": "populated_wikibase_software_validation_definition"
+		},
+		{
+			"id": "2bafc4f5-21fb-4125-80af-ec79bf6a8ef4",
+			"name": "nonarchived_wikibase_software_validation_definition"
 		}
 	]
 }

--- a/backend/data/gx/expectations/nonarchived_wikibase_software_expectation_suite.json
+++ b/backend/data/gx/expectations/nonarchived_wikibase_software_expectation_suite.json
@@ -191,7 +191,7 @@
 		},
 		{
 			"id": "677459aa-3f9c-46c4-9d79-e711adeb2f88",
-			"kwargs": { "column": "mw_bundled" },
+			"kwargs": { "column": "mw_bundled", "mostly": 0.99 },
 			"meta": {},
 			"severity": "critical",
 			"type": "expect_column_values_to_not_be_null"

--- a/backend/data/gx/expectations/nonarchived_wikibase_software_expectation_suite.json
+++ b/backend/data/gx/expectations/nonarchived_wikibase_software_expectation_suite.json
@@ -239,13 +239,6 @@
 			"type": "expect_column_to_exist"
 		},
 		{
-			"id": "4f167c64-5a66-4733-aef8-5e95a0dac3f9",
-			"kwargs": { "column": "wbs_bundled", "mostly": 0.0 },
-			"meta": {},
-			"severity": "critical",
-			"type": "expect_column_values_to_not_be_null"
-		},
-		{
 			"id": "b9b684c7-3982-4e5a-a22b-5fc3cf82a1ad",
 			"kwargs": { "column": "wbs_bundled", "value_set": [false, true] },
 			"meta": {},

--- a/backend/data/gx/expectations/nonarchived_wikibase_software_expectation_suite.json
+++ b/backend/data/gx/expectations/nonarchived_wikibase_software_expectation_suite.json
@@ -1,0 +1,288 @@
+{
+	"expectations": [
+		{
+			"id": "5186d0bf-cd58-4e83-8ac9-cf1cc2274385",
+			"kwargs": { "column": "id" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_to_exist"
+		},
+		{
+			"id": "2436ef29-36c5-4559-93da-8b926017a00a",
+			"kwargs": { "column": "id" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_be_null"
+		},
+		{
+			"id": "6ca95d62-9eeb-4435-9817-21a007dd2368",
+			"kwargs": { "column": "id" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_be_unique"
+		},
+		{
+			"id": "a04ae020-0d60-4a80-ae92-5ed52885870b",
+			"kwargs": { "column": "software_type" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_to_exist"
+		},
+		{
+			"id": "17ac7195-315c-431f-b328-5d758113a7d3",
+			"kwargs": { "column": "software_type" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_be_null"
+		},
+		{
+			"id": "5d728de7-5c72-4350-9c3c-c3d31592a3ef",
+			"kwargs": {
+				"column": "software_type",
+				"value_set": ["SOFTWARE", "SKIN", "EXTENSION", "LIBRARY"]
+			},
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_distinct_values_to_be_in_set"
+		},
+		{
+			"id": "da8f1e6a-66e2-41fd-9b5f-6fdd158a4717",
+			"kwargs": { "column": "software_name" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_to_exist"
+		},
+		{
+			"id": "32acaecc-fa3b-4cfb-a5c9-aca71ad2b345",
+			"kwargs": { "column": "software_name" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_be_null"
+		},
+		{
+			"id": "f2db309d-0430-486c-b9b8-1d6a81e307df",
+			"kwargs": {
+				"column": "software_name",
+				"regex_list": [
+					"^[ \t\r\n]*$",
+					"^[ \t\r\n]+",
+					"[ \t\r\n]+$",
+					"[ \t\r\n]{2,}"
+				]
+			},
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_match_regex_list"
+		},
+		{
+			"id": "f316d5dd-3974-4007-9865-2fbe51edcd11",
+			"kwargs": { "column_list": ["software_type", "software_name"] },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_compound_columns_to_be_unique"
+		},
+		{
+			"id": "2bf6c7a8-44f9-4566-9e57-f0459ab758f4",
+			"kwargs": { "column": "url" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_to_exist"
+		},
+		{
+			"id": "be18048d-ff1a-4d83-9389-2b4be7cd9b90",
+			"kwargs": { "column": "url" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_be_null"
+		},
+		{
+			"id": "fc428b2f-bfbd-4501-9058-fb8899685639",
+			"kwargs": { "column": "url" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_be_unique"
+		},
+		{
+			"id": "9106df93-7880-4f68-8672-a0e221ba51a5",
+			"kwargs": {
+				"column": "url",
+				"regex_list": [
+					"^[ \t\r\n]*$",
+					"^[ \t\r\n]+",
+					"[ \t\r\n]+$",
+					"[ \t\r\n]{2,}"
+				]
+			},
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_match_regex_list"
+		},
+		{
+			"id": "9182c8f3-080e-43fb-bb24-f25c352ec709",
+			"kwargs": { "column": "description" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_to_exist"
+		},
+		{
+			"id": "1eab6823-0c11-4606-b98a-24cfddd0fa21",
+			"kwargs": { "column": "description", "mostly": 0.55 },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_be_null"
+		},
+		{
+			"id": "a82411ee-3695-461d-b0de-0e1476210912",
+			"kwargs": {
+				"column": "description",
+				"regex_list": [
+					"^[ \t\r\n]*$",
+					"^[ \t\r\n]+",
+					"[ \t\r\n]+$",
+					"[ \t\r\n]{2,}"
+				]
+			},
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_match_regex_list"
+		},
+		{
+			"id": "0e19eae2-39aa-4b09-bc33-444ba2475d6b",
+			"kwargs": { "column": "latest_version" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_to_exist"
+		},
+		{
+			"id": "0f0a53ab-916c-4a52-b6bf-dd787bfe7c71",
+			"kwargs": { "column": "latest_version", "mostly": 0.49 },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_be_null"
+		},
+		{
+			"id": "6d4bab5a-911b-49eb-8384-8ecdb320ff01",
+			"kwargs": {
+				"column": "latest_version",
+				"regex_list": [
+					"^[ \t\r\n]*$",
+					"^[ \t\r\n]+",
+					"[ \t\r\n]+$",
+					"[ \t\r\n]{2,}"
+				]
+			},
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_match_regex_list"
+		},
+		{
+			"id": "5da516dc-5044-42ec-9d62-33f897d20f30",
+			"kwargs": { "column": "quarterly_download_count" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_to_exist"
+		},
+		{
+			"id": "479da3dc-7d7d-41f1-88ac-aaf89a7fece1",
+			"kwargs": { "column": "quarterly_download_count", "mostly": 0.001 },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_be_null"
+		},
+		{
+			"id": "9862d304-019a-432b-bcaa-8fe914225c5a",
+			"kwargs": { "column": "public_wiki_count" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_to_exist"
+		},
+		{
+			"id": "c9aaffa5-b706-463e-b00d-02ba8ccf310c",
+			"kwargs": { "column": "public_wiki_count", "mostly": 0.001 },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_be_null"
+		},
+		{
+			"id": "e0e7e43b-9df0-4f3c-9e95-ea6813f45ddd",
+			"kwargs": { "column": "mw_bundled" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_to_exist"
+		},
+		{
+			"id": "677459aa-3f9c-46c4-9d79-e711adeb2f88",
+			"kwargs": { "column": "mw_bundled", "mostly": 0.57 },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_be_null"
+		},
+		{
+			"id": "c9a9a10d-eb42-4ef3-a68c-9165b2e244cf",
+			"kwargs": { "column": "mw_bundled", "value_set": [false, true] },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_be_in_set"
+		},
+		{
+			"id": "4fc45491-e0b9-4a74-bf70-9886614821ba",
+			"kwargs": { "column": "fetched" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_to_exist"
+		},
+		{
+			"id": "ef8dc31f-5b13-4abe-8b97-d9ecc54332fa",
+			"kwargs": { "column": "fetched" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_be_null"
+		},
+		{
+			"id": "bfd95bd5-0756-4133-8d4a-8ccd58ca5107",
+			"kwargs": { "column": "archived" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_to_exist"
+		},
+		{
+			"id": "bf643ee9-b0eb-4500-92ea-c49d22adccf6",
+			"kwargs": { "column": "archived", "mostly": 0.57 },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_be_null"
+		},
+		{
+			"id": "0a7cdf9d-d17d-4e6e-9a2e-6f4e616e0d05",
+			"kwargs": { "column": "archived", "value_set": [false, true] },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_be_in_set"
+		},
+		{
+			"id": "f249273f-fc2d-4f7c-8701-71e4d8e4dc37",
+			"kwargs": { "column": "wbs_bundled" },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_to_exist"
+		},
+		{
+			"id": "4f167c64-5a66-4733-aef8-5e95a0dac3f9",
+			"kwargs": { "column": "wbs_bundled", "mostly": 0.0 },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_values_to_not_be_null"
+		},
+		{
+			"id": "b9b684c7-3982-4e5a-a22b-5fc3cf82a1ad",
+			"kwargs": { "column": "wbs_bundled", "value_set": [false, true] },
+			"meta": {},
+			"severity": "critical",
+			"type": "expect_column_distinct_values_to_be_in_set"
+		}
+	],
+	"id": "c3279d93-70e1-49e1-9f8c-3b707d22e8b4",
+	"meta": { "great_expectations_version": "1.18.0" },
+	"name": "nonarchived_wikibase_software_expectation_suite",
+	"notes": null
+}

--- a/backend/data/gx/expectations/nonarchived_wikibase_software_expectation_suite.json
+++ b/backend/data/gx/expectations/nonarchived_wikibase_software_expectation_suite.json
@@ -191,7 +191,7 @@
 		},
 		{
 			"id": "677459aa-3f9c-46c4-9d79-e711adeb2f88",
-			"kwargs": { "column": "mw_bundled", "mostly": 0.57 },
+			"kwargs": { "column": "mw_bundled" },
 			"meta": {},
 			"severity": "critical",
 			"type": "expect_column_values_to_not_be_null"
@@ -226,7 +226,7 @@
 		},
 		{
 			"id": "0a7cdf9d-d17d-4e6e-9a2e-6f4e616e0d05",
-			"kwargs": { "column": "archived", "value_set": [false, true] },
+			"kwargs": { "column": "archived", "value_set": [false] },
 			"meta": {},
 			"severity": "critical",
 			"type": "expect_column_values_to_be_in_set"

--- a/backend/data/gx/expectations/nonarchived_wikibase_software_expectation_suite.json
+++ b/backend/data/gx/expectations/nonarchived_wikibase_software_expectation_suite.json
@@ -154,13 +154,6 @@
 			"type": "expect_column_to_exist"
 		},
 		{
-			"id": "0f0a53ab-916c-4a52-b6bf-dd787bfe7c71",
-			"kwargs": { "column": "latest_version", "mostly": 0.49 },
-			"meta": {},
-			"severity": "critical",
-			"type": "expect_column_values_to_not_be_null"
-		},
-		{
 			"id": "6d4bab5a-911b-49eb-8384-8ecdb320ff01",
 			"kwargs": {
 				"column": "latest_version",
@@ -183,25 +176,11 @@
 			"type": "expect_column_to_exist"
 		},
 		{
-			"id": "479da3dc-7d7d-41f1-88ac-aaf89a7fece1",
-			"kwargs": { "column": "quarterly_download_count", "mostly": 0.001 },
-			"meta": {},
-			"severity": "critical",
-			"type": "expect_column_values_to_not_be_null"
-		},
-		{
 			"id": "9862d304-019a-432b-bcaa-8fe914225c5a",
 			"kwargs": { "column": "public_wiki_count" },
 			"meta": {},
 			"severity": "critical",
 			"type": "expect_column_to_exist"
-		},
-		{
-			"id": "c9aaffa5-b706-463e-b00d-02ba8ccf310c",
-			"kwargs": { "column": "public_wiki_count", "mostly": 0.001 },
-			"meta": {},
-			"severity": "critical",
-			"type": "expect_column_values_to_not_be_null"
 		},
 		{
 			"id": "e0e7e43b-9df0-4f3c-9e95-ea6813f45ddd",
@@ -244,13 +223,6 @@
 			"meta": {},
 			"severity": "critical",
 			"type": "expect_column_to_exist"
-		},
-		{
-			"id": "bf643ee9-b0eb-4500-92ea-c49d22adccf6",
-			"kwargs": { "column": "archived", "mostly": 0.57 },
-			"meta": {},
-			"severity": "critical",
-			"type": "expect_column_values_to_not_be_null"
 		},
 		{
 			"id": "0a7cdf9d-d17d-4e6e-9a2e-6f4e616e0d05",

--- a/backend/data/gx/expectations/populated_wikibase_software_expectation_suite.json
+++ b/backend/data/gx/expectations/populated_wikibase_software_expectation_suite.json
@@ -110,50 +110,10 @@
 			"type": "expect_column_to_exist"
 		},
 		{
-			"id": "1eab6823-0c11-4606-b98a-24cfddd0fa21",
-			"kwargs": { "column": "description", "mostly": 0.55 },
-			"meta": {},
-			"type": "expect_column_values_to_not_be_null"
-		},
-		{
-			"id": "a82411ee-3695-461d-b0de-0e1476210912",
-			"kwargs": {
-				"column": "description",
-				"regex_list": [
-					"^[ \t\r\n]*$",
-					"^[ \t\r\n]+",
-					"[ \t\r\n]+$",
-					"[ \t\r\n]{2,}"
-				]
-			},
-			"meta": {},
-			"type": "expect_column_values_to_not_match_regex_list"
-		},
-		{
 			"id": "0e19eae2-39aa-4b09-bc33-444ba2475d6b",
 			"kwargs": { "column": "latest_version" },
 			"meta": {},
 			"type": "expect_column_to_exist"
-		},
-		{
-			"id": "0f0a53ab-916c-4a52-b6bf-dd787bfe7c71",
-			"kwargs": { "column": "latest_version", "mostly": 0.49 },
-			"meta": {},
-			"type": "expect_column_values_to_not_be_null"
-		},
-		{
-			"id": "6d4bab5a-911b-49eb-8384-8ecdb320ff01",
-			"kwargs": {
-				"column": "latest_version",
-				"regex_list": [
-					"^[ \t\r\n]*$",
-					"^[ \t\r\n]+",
-					"[ \t\r\n]+$",
-					"[ \t\r\n]{2,}"
-				]
-			},
-			"meta": {},
-			"type": "expect_column_values_to_not_match_regex_list"
 		},
 		{
 			"id": "5da516dc-5044-42ec-9d62-33f897d20f30",
@@ -162,34 +122,16 @@
 			"type": "expect_column_to_exist"
 		},
 		{
-			"id": "479da3dc-7d7d-41f1-88ac-aaf89a7fece1",
-			"kwargs": { "column": "quarterly_download_count", "mostly": 0.001 },
-			"meta": {},
-			"type": "expect_column_values_to_not_be_null"
-		},
-		{
 			"id": "9862d304-019a-432b-bcaa-8fe914225c5a",
 			"kwargs": { "column": "public_wiki_count" },
 			"meta": {},
 			"type": "expect_column_to_exist"
 		},
 		{
-			"id": "c9aaffa5-b706-463e-b00d-02ba8ccf310c",
-			"kwargs": { "column": "public_wiki_count", "mostly": 0.001 },
-			"meta": {},
-			"type": "expect_column_values_to_not_be_null"
-		},
-		{
 			"id": "e0e7e43b-9df0-4f3c-9e95-ea6813f45ddd",
 			"kwargs": { "column": "mw_bundled" },
 			"meta": {},
 			"type": "expect_column_to_exist"
-		},
-		{
-			"id": "677459aa-3f9c-46c4-9d79-e711adeb2f88",
-			"kwargs": { "column": "mw_bundled", "mostly": 0.57 },
-			"meta": {},
-			"type": "expect_column_values_to_not_be_null"
 		},
 		{
 			"id": "c9a9a10d-eb42-4ef3-a68c-9165b2e244cf",
@@ -216,12 +158,6 @@
 			"type": "expect_column_to_exist"
 		},
 		{
-			"id": "bf643ee9-b0eb-4500-92ea-c49d22adccf6",
-			"kwargs": { "column": "archived", "mostly": 0.57 },
-			"meta": {},
-			"type": "expect_column_values_to_not_be_null"
-		},
-		{
 			"id": "0a7cdf9d-d17d-4e6e-9a2e-6f4e616e0d05",
 			"kwargs": { "column": "archived", "value_set": [false, true] },
 			"meta": {},
@@ -232,18 +168,6 @@
 			"kwargs": { "column": "wbs_bundled" },
 			"meta": {},
 			"type": "expect_column_to_exist"
-		},
-		{
-			"id": "4f167c64-5a66-4733-aef8-5e95a0dac3f9",
-			"kwargs": { "column": "wbs_bundled", "mostly": 0 },
-			"meta": {},
-			"type": "expect_column_values_to_not_be_null"
-		},
-		{
-			"id": "b9b684c7-3982-4e5a-a22b-5fc3cf82a1ad",
-			"kwargs": { "column": "wbs_bundled", "value_set": [false, true] },
-			"meta": {},
-			"type": "expect_column_distinct_values_to_be_in_set"
 		}
 	],
 	"id": "a4fe5870-c78d-433d-af64-76b02603e528",

--- a/backend/data/gx/great_expectations.yml
+++ b/backend/data/gx/great_expectations.yml
@@ -95,7 +95,6 @@ fluent_datasources:
             id: 7d5132d1-89d4-4808-9857-e99931257217
             partitioner:
         table_name: alembic_version
-        schema_name:
       wikibase_table:
         type: table
         id: 779de8a9-4658-46c1-9622-389d18fe00e5
@@ -105,7 +104,6 @@ fluent_datasources:
             id: 420cc603-a309-4434-a22f-6f2d194e3611
             partitioner:
         table_name: wikibase
-        schema_name:
       wikibase_category_table:
         type: table
         id: 07fad760-0d4b-4f38-bde7-4ff1bdf3ee1b
@@ -115,7 +113,6 @@ fluent_datasources:
             id: adf99891-4cb3-4594-bdf8-14a86f927a74
             partitioner:
         table_name: wikibase_category
-        schema_name:
       wikibase_connectivity_observation_table:
         type: table
         id: baa8a84b-f3b7-475f-b310-507591390c0c
@@ -125,7 +122,6 @@ fluent_datasources:
             id: e4cd9bb8-d53e-4649-9b5d-7775f03d753a
             partitioner:
         table_name: wikibase_connectivity_observation
-        schema_name:
       wikibase_connectivity_observation_item_relationship_count_table:
         type: table
         id: 8acebf61-1e1c-4a2a-8939-2218b72f9f56
@@ -135,7 +131,6 @@ fluent_datasources:
             id: 5a83c4c9-2a2b-4892-89a0-de22cfc6e544
             partitioner:
         table_name: wikibase_connectivity_observation_item_relationship_count
-        schema_name:
       wikibase_connectivity_observation_object_relationship_count_table:
         type: table
         id: 4bb149c0-f1f8-4ad2-a62d-48f4c36a9b27
@@ -145,7 +140,6 @@ fluent_datasources:
             id: f9016371-5309-4e38-b627-280d633be15e
             partitioner:
         table_name: wikibase_connectivity_observation_object_relationship_count
-        schema_name:
       wikibase_log_observation_month_table:
         type: table
         id: 254c7785-cfcf-4f90-b564-42cb429eea6e
@@ -155,7 +149,6 @@ fluent_datasources:
             id: e00ad34a-5a21-4fa2-8f71-e2a524063cd2
             partitioner:
         table_name: wikibase_log_observation_month
-        schema_name:
       wikibase_log_observation_month_type_table:
         type: table
         id: 7cfcf9da-85d0-4082-bcf0-fd6e7c85141a
@@ -165,7 +158,6 @@ fluent_datasources:
             id: ef9eae68-e7b8-453a-83da-73a8ecbed2b4
             partitioner:
         table_name: wikibase_log_observation_month_type
-        schema_name:
       wikibase_log_observation_month_user_table:
         type: table
         id: 3fb1783b-0026-4da6-bc41-ba47f87d6d85
@@ -175,7 +167,6 @@ fluent_datasources:
             id: f9900adb-307a-45d2-babf-c895c6a05939
             partitioner:
         table_name: wikibase_log_observation_month_user
-        schema_name:
       wikibase_property_usage_count_table:
         type: table
         id: 421ea124-d4fe-4504-a338-417fbbea1625
@@ -185,7 +176,6 @@ fluent_datasources:
             id: d6a6fcf0-d2c0-4951-b10b-c36cc04838fc
             partitioner:
         table_name: wikibase_property_usage_count
-        schema_name:
       wikibase_property_usage_observation_table:
         type: table
         id: 81cfc867-4dc4-49d0-b47c-d093124ebea1
@@ -195,7 +185,6 @@ fluent_datasources:
             id: 5188a790-d406-4300-a0e5-e9d73db8a65e
             partitioner:
         table_name: wikibase_property_usage_observation
-        schema_name:
       wikibase_quantity_observation_table:
         type: table
         id: d6ad1b86-b45c-4570-83da-76534f1f9af4
@@ -205,7 +194,6 @@ fluent_datasources:
             id: 23ccdc9a-badb-41cd-b894-480813b3d70c
             partitioner:
         table_name: wikibase_quantity_observation
-        schema_name:
       wikibase_software_version_table:
         type: table
         id: 2db8b8c6-0bbb-4af5-afc8-7856204b770c
@@ -215,7 +203,6 @@ fluent_datasources:
             id: 0829cb63-1a66-4698-b3bc-d358a81d780c
             partitioner:
         table_name: wikibase_software_version
-        schema_name:
       wikibase_software_version_observation_table:
         type: table
         id: 9ebe19ff-8664-4b55-9877-63ef5de67df0
@@ -225,7 +212,6 @@ fluent_datasources:
             id: 673e6508-d457-49bb-b25e-07b1f73773c8
             partitioner:
         table_name: wikibase_software_version_observation
-        schema_name:
       wikibase_statistics_observation_table:
         type: table
         id: 05cc691f-d972-4cdd-8172-86dc600cf18e
@@ -235,7 +221,6 @@ fluent_datasources:
             id: 96994a6a-aa72-4eb2-96b8-c285a7291b69
             partitioner:
         table_name: wikibase_statistics_observation
-        schema_name:
       wikibase_url_table:
         type: table
         id: 4d09e485-87d2-4982-965b-1d5a797c31e1
@@ -245,7 +230,6 @@ fluent_datasources:
             id: 0088e7de-143c-43dc-8bfe-f08f32376b05
             partitioner:
         table_name: wikibase_url
-        schema_name:
       wikibase_path:
         type: query
         id: ffd510db-030a-4beb-ba71-badc5324993a
@@ -275,7 +259,6 @@ fluent_datasources:
             id: f1ae068c-b242-4529-a90f-25f108f95f4c
             partitioner:
         table_name: wikibase_user_group
-        schema_name:
       wikibase_user_observation_table:
         type: table
         id: 887fb86a-a044-4376-8d84-b51880ec5b49
@@ -285,7 +268,6 @@ fluent_datasources:
             id: 0206ca46-ca6f-4806-98dd-d0c97852e049
             partitioner:
         table_name: wikibase_user_observation
-        schema_name:
       wikibase_user_observation_group_table:
         type: table
         id: 327881eb-4b05-4aa1-b1c4-c020eadba500
@@ -295,7 +277,6 @@ fluent_datasources:
             id: 68d93746-86ad-4c48-9bb1-bc3df4080828
             partitioner:
         table_name: wikibase_user_observation_group
-        schema_name:
       valid_wikibases:
         type: query
         id: dc0d4790-c1d7-40ad-9bfb-c6accca74b07
@@ -378,7 +359,6 @@ fluent_datasources:
             id: 550b72d7-9aca-40cc-9d2a-7f94fcb44828
             partitioner:
         table_name: wikibase_software
-        schema_name:
       wikibase_software_tag_table:
         type: table
         id: d27a75dc-0e2e-43b2-91da-a1f2e9e0590a
@@ -388,7 +368,6 @@ fluent_datasources:
             id: 3b69d250-8f9a-4d11-b5a2-82463d829103
             partitioner:
         table_name: wikibase_software_tag
-        schema_name:
       wikibase_software_tag_xref_table:
         type: table
         id: 7f899383-9ce6-4afa-8dbb-0e49c30f3fd5
@@ -398,7 +377,6 @@ fluent_datasources:
             id: ce729967-02a8-4e8f-b43a-c0d4ac078e44
             partitioner:
         table_name: wikibase_software_tag_xref
-        schema_name:
       populated_wikibase_software_records:
         type: query
         id: 97690d4d-e26a-4c89-807c-98e2a760e648
@@ -417,7 +395,6 @@ fluent_datasources:
             id: ef258a6b-943c-4e72-97d6-48205e388e01
             partitioner:
         table_name: wikibase_language
-        schema_name:
       wikibase_language_count:
         type: query
         id: de236522-ceb5-4822-a550-388b53c8dfb6
@@ -439,7 +416,6 @@ fluent_datasources:
             id: a71651ed-6dd3-4505-9d48-74e3460fbdbe
             partitioner:
         table_name: wikibase_recent_changes_observation
-        schema_name:
       valid_wikibase_recent_changes_observation:
         type: query
         id: 196cd05d-8531-4a31-a37a-dffe52e07120
@@ -458,7 +434,6 @@ fluent_datasources:
             id: b405d32b-c814-4c90-beb4-49cda0998675
             partitioner:
         table_name: wikibase_external_identifier_observation
-        schema_name:
       valid_wikibase_external_identifier_observation:
         type: query
         id: e8cfc10d-6e74-41ab-823c-2f2489d3df18

--- a/backend/data/gx/great_expectations.yml
+++ b/backend/data/gx/great_expectations.yml
@@ -469,5 +469,15 @@ fluent_datasources:
             partitioner:
         query: SELECT * FROM wikibase_external_identifier_observation WHERE
           anything
+      nonarchived_wikibase_software_records:
+        type: query
+        id: 292ccce6-1972-4824-ad7b-696d6a40935e
+        batch_metadata: {}
+        batch_definitions:
+          FULL_TABLE:
+            id: 657f9d7e-339f-492e-8baf-59a5d47a0bda
+            partitioner:
+        query: SELECT * FROM wikibase_software WHERE url IS NOT NULL AND NOT
+          archived
     connection_string: ${DATABASE_URL_SYNC}
 data_context_id: 14fd50bc-47c8-4033-9643-e60c471dc6c5

--- a/backend/data/gx/validation_definitions/nonarchived_wikibase_software_validation_definition.json
+++ b/backend/data/gx/validation_definitions/nonarchived_wikibase_software_validation_definition.json
@@ -1,0 +1,22 @@
+{
+	"data": {
+		"asset": {
+			"id": "292ccce6-1972-4824-ad7b-696d6a40935e",
+			"name": "nonarchived_wikibase_software_records"
+		},
+		"batch_definition": {
+			"id": "657f9d7e-339f-492e-8baf-59a5d47a0bda",
+			"name": "FULL_TABLE"
+		},
+		"datasource": {
+			"id": "4a58b404-1ee3-4e91-a373-78d1b365f987",
+			"name": "wikibase_datasource"
+		}
+	},
+	"id": "2bafc4f5-21fb-4125-80af-ec79bf6a8ef4",
+	"name": "nonarchived_wikibase_software_validation_definition",
+	"suite": {
+		"id": "c3279d93-70e1-49e1-9f8c-3b707d22e8b4",
+		"name": "nonarchived_wikibase_software_expectation_suite"
+	}
+}

--- a/backend/fetch_data/soup_data/software/get_update_software_data.py
+++ b/backend/fetch_data/soup_data/software/get_update_software_data.py
@@ -1,13 +1,16 @@
 """Update Software Data"""
 
 import asyncio
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 import re
-from typing import Iterable, List, Optional
+from typing import List, Optional
+
 from bs4 import BeautifulSoup
 import requests
 from sqlalchemy import Select, and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+
 from data import get_async_session
 from fetch_data.utils import clean_string
 from logger import logger
@@ -40,47 +43,51 @@ async def update_software_data():
 
 async def compile_data_from_url(
     async_session: AsyncSession,
-    ext: WikibaseSoftwareModel,
+    model: WikibaseSoftwareModel,
     override_url: Optional[str] = None,
     archived: bool = False,
 ):
     """Compile Software Data from URL"""
 
+    assert (url := override_url or model.url) is not None
+
     with await asyncio.to_thread(
-        requests.get, override_url or ext.url, timeout=300, allow_redirects=True
+        requests.get, url, timeout=300, allow_redirects=True
     ) as response:
 
-        ext.data_fetched = datetime.now(timezone.utc)
+        model.data_fetched = datetime.now(timezone.utc)
         logger.info(f"{response.url}: {response.status_code}")
 
-        if response.status_code == 200:
+        if response.status_code != 200:
+            logger.warning(f"Software Returned {response.status_code}: {url}")
 
-            if override_url is None and response.url != ext.url:
-                ext.url = response.url
+        else:
+            if override_url is None and response.url != model.url:
+                model.url = response.url
 
             soup = BeautifulSoup(response.content, features="html.parser")
 
             page_archived = (
                 soup.find("b", string="This extension has been archived.") is not None
             )
-            ext.archived = archived or page_archived
+            model.archived = archived or page_archived
             if page_archived:
                 permanent_link_tag = soup.find(
                     "a", string="To see the page before archival, click here."
                 )
                 return await compile_data_from_url(
                     async_session,
-                    ext,
+                    model,
                     override_url=f"https://www.mediawiki.org{permanent_link_tag['href']}",
                     archived=True,
                 )
 
-            ext.tags = await compile_tag_list(async_session, soup)
-            ext.description = compile_description(soup)
-            ext.latest_version = compile_latest_version(soup)
-            ext.quarterly_download_count = compile_quarterly_count(soup)
-            ext.public_wiki_count = compile_wiki_count(soup)
-            ext.mediawiki_bundled = compile_bundled(soup)
+            model.tags = await compile_tag_list(async_session, soup)
+            model.description = compile_description(soup)
+            model.latest_version = compile_latest_version(soup)
+            model.quarterly_download_count = compile_quarterly_count(soup)
+            model.public_wiki_count = compile_wiki_count(soup)
+            model.mediawiki_bundled = compile_bundled(soup)
 
 
 def get_update_extension_query() -> Select[WikibaseSoftwareModel]:

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,7 +1,7 @@
 alembic-postgresql-enum>=1.10
 black>=26.3.1
 freezegun>=1.5.5
-great-expectations>=1.17.1
+great-expectations>=1.18
 psycopg2-binary>=2.9.12
 pylint>=4.0.5
 pytest>=9.0.3


### PR DESCRIPTION
* Create nonarchived_wikibase_software_expectation_suite, with appropriate query and validation definition added to relevant checkpoint
* Move checks except archived into nonarchived_wikibase_software_expectation_suite - use best judgement re relevance
* Periodic recheck already in place
* Remove unneeded expectations
* Reset most expectations to 100% 